### PR TITLE
feat: add QUERY to POST plugin

### DIFF
--- a/apisix/cli/config.lua
+++ b/apisix/cli/config.lua
@@ -254,6 +254,7 @@ local _M = {
     "proxy-mirror",
     "graphql-proxy-cache",
     "proxy-rewrite",
+    "query-to-post",
     "workflow",
     "api-breaker",
     "graphql-limit-count",

--- a/apisix/plugins/query-to-post.lua
+++ b/apisix/plugins/query-to-post.lua
@@ -1,0 +1,80 @@
+--
+-- Licensed to the Apache Software Foundation (ASF) under one or more
+-- contributor license agreements.  See the NOTICE file distributed with
+-- this work for additional information regarding copyright ownership.
+-- The ASF licenses this file to You under the Apache License, Version 2.0
+-- (the "License"); you may not use this file except in compliance with
+-- the License.  You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+local core        = require("apisix.core")
+local ngx         = ngx
+local plugin_name = "query-to-post"
+
+local schema = {
+    type = "object",
+    properties = {
+        preserve_original_method_header = {
+            description = "whether to forward the original request method",
+            type = "boolean",
+            default = true,
+        },
+        original_method_header = {
+            description = "header used to forward the original request method",
+            type = "string",
+            default = "X-Original-Method",
+            minLength = 1,
+            maxLength = 128,
+        },
+    },
+    additionalProperties = false,
+}
+
+local _M = {
+    version  = 0.1,
+    priority = -1001,
+    name     = plugin_name,
+    schema   = schema,
+}
+
+
+function _M.check_schema(conf)
+    local ok, err = core.schema.check(schema, conf)
+    if not ok then
+        return false, err
+    end
+
+    if conf.preserve_original_method_header ~= false
+        and not core.utils.validate_header_field(conf.original_method_header
+            or "X-Original-Method") then
+        return false, "invalid original_method_header"
+    end
+
+    return true
+end
+
+
+function _M.access(conf, ctx)
+    local method = ngx.req.get_method()
+    if method ~= "QUERY" then
+        return
+    end
+
+    ctx.query_to_post_original_method = method
+
+    if conf.preserve_original_method_header ~= false then
+        core.request.set_header(ctx, conf.original_method_header or "X-Original-Method", method)
+    end
+
+    ngx.req.set_method(ngx.HTTP_POST)
+end
+
+
+return _M

--- a/apisix/schema_def.lua
+++ b/apisix/schema_def.lua
@@ -145,13 +145,6 @@ local method_schema = {
         "OPTIONS", "CONNECT", "TRACE", "PURGE"},
 }
 
-local route_method_schema = {
-    description = "HTTP method",
-    type = "string",
-    enum = {"GET", "POST", "PUT", "DELETE", "PATCH", "HEAD",
-        "OPTIONS", "CONNECT", "TRACE", "PURGE", "QUERY"},
-}
-
 
 local health_checker_active = {
     type = "object",
@@ -603,7 +596,7 @@ _M.route = {
 
         methods = {
             type = "array",
-            items = route_method_schema,
+            items = method_schema,
             uniqueItems = true,
         },
         host = host_def,

--- a/apisix/schema_def.lua
+++ b/apisix/schema_def.lua
@@ -145,6 +145,13 @@ local method_schema = {
         "OPTIONS", "CONNECT", "TRACE", "PURGE"},
 }
 
+local route_method_schema = {
+    description = "HTTP method",
+    type = "string",
+    enum = {"GET", "POST", "PUT", "DELETE", "PATCH", "HEAD",
+        "OPTIONS", "CONNECT", "TRACE", "PURGE", "QUERY"},
+}
+
 
 local health_checker_active = {
     type = "object",
@@ -596,7 +603,7 @@ _M.route = {
 
         methods = {
             type = "array",
-            items = method_schema,
+            items = route_method_schema,
             uniqueItems = true,
         },
         host = host_def,

--- a/docs/en/latest/config.json
+++ b/docs/en/latest/config.json
@@ -110,6 +110,7 @@
             "plugins/response-rewrite",
             "plugins/error-page",
             "plugins/proxy-rewrite",
+            "plugins/query-to-post",
             "plugins/grpc-transcode",
             "plugins/grpc-web",
             "plugins/fault-injection",

--- a/docs/en/latest/plugins/query-to-post.md
+++ b/docs/en/latest/plugins/query-to-post.md
@@ -1,0 +1,88 @@
+---
+title: Query to Post
+keywords:
+  - Apache APISIX
+  - API Gateway
+  - QUERY
+  - HTTP method
+description: The query-to-post Plugin forwards QUERY requests to POST-only Upstream services.
+---
+
+<!--
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+-->
+
+## Description
+
+The `query-to-post` Plugin forwards HTTP `QUERY` requests to Upstream services as `POST` requests. It does not read, modify, or re-encode the request body.
+
+Configure the Plugin only on Routes that explicitly match the `QUERY` method. Route matching and request security policies run against the client method. The method is changed immediately before APISIX proxies the request to the Upstream service.
+
+## Attributes
+
+| Name | Type | Required | Default | Description |
+|------|------|----------|---------|-------------|
+| `preserve_original_method_header` | boolean | False | `true` | Forward the original method to Upstream. |
+| `original_method_header` | string | False | `X-Original-Method` | Header used to forward the original method. APISIX overwrites an incoming header with the same name. |
+
+## Example
+
+Create a Route that accepts `QUERY` requests and forwards them to a POST-only search service:
+
+```shell
+curl "http://127.0.0.1:9180/apisix/admin/routes/query-search" -X PUT \
+  -H "X-API-KEY: ${admin_key}" \
+  -d '{
+    "uri": "/v1/search",
+    "methods": ["QUERY"],
+    "plugins": {
+      "query-to-post": {}
+    },
+    "upstream": {
+      "type": "roundrobin",
+      "nodes": {
+        "search.internal:8080": 1
+      }
+    }
+  }'
+```
+
+A client can issue a QUERY request with a body:
+
+```shell
+curl "http://127.0.0.1:9080/v1/search" \
+  -X QUERY \
+  -H "Content-Type: application/json" \
+  --data '{"query":"apisix"}'
+```
+
+The Upstream receives:
+
+```text
+POST /v1/search
+X-Original-Method: QUERY
+Content-Type: application/json
+
+{"query":"apisix"}
+```
+
+## Notes
+
+- The Plugin only transforms `QUERY` requests. Requests using other methods are left unchanged.
+- Configure `methods: ["QUERY"]` on the Route to prevent POST requests from matching the same Route.
+- The Plugin does not add request-body-aware caching. Cache policy is a separate concern.

--- a/docs/en/latest/plugins/query-to-post.md
+++ b/docs/en/latest/plugins/query-to-post.md
@@ -31,7 +31,7 @@ description: The query-to-post Plugin forwards QUERY requests to POST-only Upstr
 
 The `query-to-post` Plugin forwards HTTP `QUERY` requests to Upstream services as `POST` requests. It does not read, modify, or re-encode the request body.
 
-Configure the Plugin only on Routes that explicitly match the `QUERY` method. Route matching and request security policies run against the client method. The method is changed immediately before APISIX proxies the request to the Upstream service.
+Configure the Plugin only on Routes that explicitly match `request_method == QUERY`. Route matching and request security policies run against the client method. The method is changed immediately before APISIX proxies the request to the Upstream service.
 
 ## Attributes
 
@@ -49,7 +49,7 @@ curl "http://127.0.0.1:9180/apisix/admin/routes/query-search" -X PUT \
   -H "X-API-KEY: ${admin_key}" \
   -d '{
     "uri": "/v1/search",
-    "methods": ["QUERY"],
+    "vars": [["request_method", "==", "QUERY"]],
     "plugins": {
       "query-to-post": {}
     },
@@ -84,5 +84,5 @@ Content-Type: application/json
 ## Notes
 
 - The Plugin only transforms `QUERY` requests. Requests using other methods are left unchanged.
-- Configure `methods: ["QUERY"]` on the Route to prevent POST requests from matching the same Route.
+- Match `QUERY` explicitly with `vars: [["request_method", "==", "QUERY"]]` to prevent POST requests from matching the same Route.
 - The Plugin does not add request-body-aware caching. Cache policy is a separate concern.

--- a/t/admin/plugins.t
+++ b/t/admin/plugins.t
@@ -116,6 +116,7 @@ ai-lakera-guard
 proxy-mirror
 graphql-proxy-cache
 proxy-rewrite
+query-to-post
 workflow
 api-breaker
 graphql-limit-count

--- a/t/admin/plugins.t
+++ b/t/admin/plugins.t
@@ -116,7 +116,6 @@ ai-lakera-guard
 proxy-mirror
 graphql-proxy-cache
 proxy-rewrite
-query-to-post
 workflow
 api-breaker
 graphql-limit-count
@@ -158,6 +157,7 @@ clickhouse-logger
 tencent-cloud-cls
 inspect
 example-plugin
+query-to-post
 aws-lambda
 azure-functions
 openwhisk

--- a/t/plugin/query-to-post.t
+++ b/t/plugin/query-to-post.t
@@ -82,7 +82,7 @@ invalid original_method_header/
             local t = require("lib.test_admin").test
             local code, body = t('/apisix/admin/routes/1',
                  ngx.HTTP_PUT,
-                 [[{
+                 [=[{
                     "vars": [["request_method", "==", "QUERY"]],
                     "plugins": {
                         "proxy-rewrite": {
@@ -97,7 +97,7 @@ invalid original_method_header/
                         "type": "roundrobin"
                     },
                     "uri": "/query-to-post"
-                }]]
+                }]=]
             )
 
             if code >= 300 then
@@ -131,7 +131,7 @@ x-real-ip: 127.0.0.1
             local t = require("lib.test_admin").test
             local code, body = t('/apisix/admin/routes/1',
                  ngx.HTTP_PUT,
-                 [[{
+                 [=[{
                     "vars": [["request_method", "==", "QUERY"]],
                     "plugins": {
                         "proxy-rewrite": {
@@ -146,7 +146,7 @@ x-real-ip: 127.0.0.1
                         "type": "roundrobin"
                     },
                     "uri": "/query-to-post/body"
-                }]]
+                }]=]
             )
 
             if code >= 300 then

--- a/t/plugin/query-to-post.t
+++ b/t/plugin/query-to-post.t
@@ -1,0 +1,180 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+BEGIN {
+    if ($ENV{TEST_NGINX_CHECK_LEAK}) {
+        $SkipReason = "unavailable for the hup tests";
+    } else {
+        $ENV{TEST_NGINX_USE_HUP} = 1;
+        undef $ENV{TEST_NGINX_USE_STAP};
+    }
+}
+
+use t::APISIX 'no_plan';
+
+repeat_each(1);
+no_long_string();
+no_shuffle();
+no_root_location();
+run_tests;
+
+__DATA__
+
+=== TEST 1: validate plugin schema
+--- config
+    location /t {
+        content_by_lua_block {
+            local plugin = require("apisix.plugins.query-to-post")
+            local ok, err = plugin.check_schema({
+                original_method_header = "X-Original-Method",
+            })
+            if not ok then
+                ngx.say(err)
+            end
+
+            ngx.say("done")
+        }
+    }
+--- request
+GET /t
+--- response_body
+done
+
+
+
+=== TEST 2: reject an invalid original method header
+--- config
+    location /t {
+        content_by_lua_block {
+            local plugin = require("apisix.plugins.query-to-post")
+            local ok, err = plugin.check_schema({
+                original_method_header = "Bad:Header",
+            })
+            ngx.say(ok)
+            ngx.say(err)
+        }
+    }
+--- request
+GET /t
+--- response_body_like eval
+qr/false
+invalid original_method_header/
+
+
+
+=== TEST 3: add a QUERY route
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1',
+                 ngx.HTTP_PUT,
+                 [[{
+                    "methods": ["QUERY"],
+                    "plugins": {
+                        "proxy-rewrite": {
+                            "uri": "/uri/plugin_proxy_rewrite"
+                        },
+                        "query-to-post": {}
+                    },
+                    "upstream": {
+                        "nodes": {
+                            "127.0.0.1:1980": 1
+                        },
+                        "type": "roundrobin"
+                    },
+                    "uri": "/query-to-post"
+                }]]
+            )
+
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed
+
+
+
+=== TEST 4: transform QUERY to POST and preserve the original method
+--- request
+QUERY /query-to-post
+--- response_body
+uri: /uri/plugin_proxy_rewrite
+host: localhost
+x-original-method: QUERY
+x-real-ip: 127.0.0.1
+
+
+
+=== TEST 5: update route to forward the request body
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1',
+                 ngx.HTTP_PUT,
+                 [[{
+                    "methods": ["QUERY"],
+                    "plugins": {
+                        "proxy-rewrite": {
+                            "uri": "/echo"
+                        },
+                        "query-to-post": {}
+                    },
+                    "upstream": {
+                        "nodes": {
+                            "127.0.0.1:1980": 1
+                        },
+                        "type": "roundrobin"
+                    },
+                    "uri": "/query-to-post/body"
+                }]]
+            )
+
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed
+
+
+
+=== TEST 6: preserve QUERY request body
+--- more_headers
+Content-Type: application/json
+--- request
+QUERY /query-to-post/body
+{"query":"apisix"}
+--- response_body_like eval
+qr/{"query":"apisix"}/
+
+
+
+=== TEST 7: do not match POST on a QUERY-only route
+--- request
+POST /query-to-post/body
+{"query":"apisix"}
+--- error_code: 404

--- a/t/plugin/query-to-post.t
+++ b/t/plugin/query-to-post.t
@@ -83,7 +83,7 @@ invalid original_method_header/
             local code, body = t('/apisix/admin/routes/1',
                  ngx.HTTP_PUT,
                  [[{
-                    "methods": ["QUERY"],
+                    "vars": [["request_method", "==", "QUERY"]],
                     "plugins": {
                         "proxy-rewrite": {
                             "uri": "/uri/plugin_proxy_rewrite"
@@ -132,7 +132,7 @@ x-real-ip: 127.0.0.1
             local code, body = t('/apisix/admin/routes/1',
                  ngx.HTTP_PUT,
                  [[{
-                    "methods": ["QUERY"],
+                    "vars": [["request_method", "==", "QUERY"]],
                     "plugins": {
                         "proxy-rewrite": {
                             "uri": "/echo"


### PR DESCRIPTION
## Summary

- add the `query-to-post` Plugin for forwarding QUERY requests to POST-only Upstreams
- match QUERY routes through the existing `request_method` route variable
- preserve the client method in `X-Original-Method` by default
- add integration coverage and plugin documentation

## Behavior

Routes must explicitly match `request_method == QUERY` with `vars: [["request_method", "==", "QUERY"]]`. The Plugin transforms only QUERY requests after route matching and policy processing; request bodies are forwarded unchanged.

## Validation

- reviewed the branch diff and plugin registration
- integration tests were added in `t/plugin/query-to-post.t`
- GitHub Actions is validating the latest fixes