### PR TITLE
feat: add runtime Redis profiles

### DIFF
--- a/apisix/admin/init.lua
+++ b/apisix/admin/init.lua
@@ -71,6 +71,7 @@ local resources = {
     plugin_configs  = require("apisix.admin.plugin_config"),
     consumer_groups = require("apisix.admin.consumer_group"),
     secrets         = require("apisix.admin.secrets"),
+    redis_profiles  = require("apisix.admin.redis_profiles"),
 }
 
 

--- a/apisix/admin/redis_profiles.lua
+++ b/apisix/admin/redis_profiles.lua
@@ -1,41 +1,40 @@
+--
+-- Licensed to the Apache Software Foundation (ASF) under one or more
+-- contributor license agreements.  See the NOTICE file distributed with
+-- this work for additional information regarding copyright ownership.
+-- The ASF licenses this file to You under the Apache License, Version 2.0
+-- (the "License"); you may not use this file except in compliance with
+-- the License.  You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
 local core = require("apisix.core")
 local resource = require("apisix.admin.resource")
-
-local schema = {
-    type = "object",
-    properties = {
-        mode = {type = "string", enum = {"standalone", "cluster", "sentinel"}},
-        host = {type = "string"}, port = {type = "integer", minimum = 1},
-        nodes = {type = "array", items = {type = "string"}},
-        cluster_name = {type = "string"}, sentinels = {type = "array"},
-        master_name = {type = "string"}, username = {type = "string"},
-        password = {type = "string"}, database = {type = "integer", minimum = 0},
-    },
-    required = {"mode"},
-    additionalProperties = false,
-}
+local redis_profile = require("apisix.core.redis_profile")
 
 local function check_conf(_, conf)
-    local ok, err = core.schema.check(schema, conf)
-    if not ok then
-        return false, err
+    return redis_profile.check_conf(conf)
+end
+
+local function encrypt_conf(_, conf)
+    if conf.password then
+        conf.password = core.data_encryption.encrypt(conf.password)
     end
-    if conf.mode == "standalone" and not conf.host then
-        return false, "standalone profile requires host"
+    if conf.sentinel_password then
+        conf.sentinel_password = core.data_encryption.encrypt(conf.sentinel_password)
     end
-    if conf.mode == "cluster" and (not conf.nodes or #conf.nodes == 0) then
-        return false, "cluster profile requires nodes"
-    end
-    if conf.mode == "sentinel" and (not conf.sentinels or #conf.sentinels == 0
-        or not conf.master_name) then
-        return false, "sentinel profile requires sentinels and master_name"
-    end
-    return true
 end
 
 return resource.new({
     name = "redis_profiles",
     kind = "redis_profile",
-    schema = schema,
+    schema = redis_profile.schema,
     checker = check_conf,
+    encrypt_conf = encrypt_conf,
 })

--- a/apisix/admin/redis_profiles.lua
+++ b/apisix/admin/redis_profiles.lua
@@ -22,13 +22,26 @@ local function check_conf(_, conf)
     return redis_profile.check_conf(conf)
 end
 
+local function encrypt_field(conf, field, subject)
+    local value = conf[field]
+    if not value then
+        return
+    end
+
+    -- PATCH starts from the existing etcd value. Unlike plugin resources,
+    -- redis profiles are not processed by utils.decrypt_params, so an
+    -- unchanged password is still ciphertext here. Do not encrypt it again.
+    local decrypted = core.data_encryption.decrypt(value, subject)
+    if decrypted then
+        return
+    end
+
+    conf[field] = core.data_encryption.encrypt(value)
+end
+
 local function encrypt_conf(_, conf)
-    if conf.redis_password then
-        conf.redis_password = core.data_encryption.encrypt(conf.redis_password)
-    end
-    if conf.sentinel_password then
-        conf.sentinel_password = core.data_encryption.encrypt(conf.sentinel_password)
-    end
+    encrypt_field(conf, "redis_password", "redis password")
+    encrypt_field(conf, "sentinel_password", "redis sentinel password")
 end
 
 return resource.new({

--- a/apisix/admin/redis_profiles.lua
+++ b/apisix/admin/redis_profiles.lua
@@ -23,8 +23,8 @@ local function check_conf(_, conf)
 end
 
 local function encrypt_conf(_, conf)
-    if conf.password then
-        conf.password = core.data_encryption.encrypt(conf.password)
+    if conf.redis_password then
+        conf.redis_password = core.data_encryption.encrypt(conf.redis_password)
     end
     if conf.sentinel_password then
         conf.sentinel_password = core.data_encryption.encrypt(conf.sentinel_password)

--- a/apisix/admin/redis_profiles.lua
+++ b/apisix/admin/redis_profiles.lua
@@ -1,0 +1,41 @@
+local core = require("apisix.core")
+local resource = require("apisix.admin.resource")
+
+local schema = {
+    type = "object",
+    properties = {
+        mode = {type = "string", enum = {"standalone", "cluster", "sentinel"}},
+        host = {type = "string"}, port = {type = "integer", minimum = 1},
+        nodes = {type = "array", items = {type = "string"}},
+        cluster_name = {type = "string"}, sentinels = {type = "array"},
+        master_name = {type = "string"}, username = {type = "string"},
+        password = {type = "string"}, database = {type = "integer", minimum = 0},
+    },
+    required = {"mode"},
+    additionalProperties = false,
+}
+
+local function check_conf(_, conf)
+    local ok, err = core.schema.check(schema, conf)
+    if not ok then
+        return false, err
+    end
+    if conf.mode == "standalone" and not conf.host then
+        return false, "standalone profile requires host"
+    end
+    if conf.mode == "cluster" and (not conf.nodes or #conf.nodes == 0) then
+        return false, "cluster profile requires nodes"
+    end
+    if conf.mode == "sentinel" and (not conf.sentinels or #conf.sentinels == 0
+        or not conf.master_name) then
+        return false, "sentinel profile requires sentinels and master_name"
+    end
+    return true
+end
+
+return resource.new({
+    name = "redis_profiles",
+    kind = "redis_profile",
+    schema = schema,
+    checker = check_conf,
+})

--- a/apisix/core/redis_profile.lua
+++ b/apisix/core/redis_profile.lua
@@ -16,7 +16,7 @@
 --
 local core = require("apisix.core")
 local error = error
-local ipairs = ipairs
+local pairs = pairs
 local type = type
 
 local _M = {
@@ -27,16 +27,6 @@ local prefix = "redis-profile://"
 local profiles
 local profile_cache = setmetatable({}, {__mode = "k"})
 
-local endpoint_schema = {
-    type = "object",
-    properties = {
-        host = {type = "string", minLength = 1},
-        port = {type = "integer", minimum = 1, maximum = 65535},
-    },
-    required = {"host", "port"},
-    additionalProperties = false,
-}
-
 local schema = {
     type = "object",
     properties = {
@@ -46,29 +36,32 @@ local schema = {
         create_time = {type = "integer"},
         update_time = {type = "integer"},
         mode = {type = "string", enum = {"standalone", "cluster", "sentinel"}},
-        host = {type = "string", minLength = 1},
-        port = {type = "integer", minimum = 1, maximum = 65535},
-        nodes = {
+        redis_host = {type = "string", minLength = 1},
+        redis_port = {type = "integer", minimum = 1, maximum = 65535},
+        redis_cluster_nodes = {
             type = "array",
             minItems = 1,
-            items = {oneOf = {{type = "string", minLength = 1}, endpoint_schema}},
+            items = {type = "string", minLength = 1},
         },
-        sentinels = {type = "array", minItems = 1, items = endpoint_schema},
-        cluster_name = {type = "string", minLength = 1},
-        master_name = {type = "string", minLength = 1},
-        username = {type = "string", minLength = 1},
-        password = {type = "string", minLength = 0},
+        redis_sentinels = {type = "array", minItems = 1,
+            items = {type = "string", minLength = 1}},
+        redis_cluster_name = {type = "string", minLength = 1},
+        redis_master_name = {type = "string", minLength = 1},
+        redis_username = {type = "string", minLength = 1},
+        redis_password = {type = "string", minLength = 0},
         sentinel_username = {type = "string", minLength = 1},
         sentinel_password = {type = "string", minLength = 0},
-        database = {type = "integer", minimum = 0},
-        timeout = {type = "integer", minimum = 1},
-        connect_timeout = {type = "integer", minimum = 1},
-        read_timeout = {type = "integer", minimum = 1},
-        keepalive_timeout = {type = "integer", minimum = 1},
-        keepalive_pool = {type = "integer", minimum = 1},
-        ssl = {type = "boolean"},
-        ssl_verify = {type = "boolean"},
-        role = {type = "string", enum = {"master", "slave"}},
+        redis_database = {type = "integer", minimum = 0},
+        redis_timeout = {type = "integer", minimum = 1},
+        redis_connect_timeout = {type = "integer", minimum = 1},
+        redis_read_timeout = {type = "integer", minimum = 1},
+        redis_keepalive_timeout = {type = "integer", minimum = 1},
+        redis_keepalive_pool = {type = "integer", minimum = 1},
+        redis_ssl = {type = "boolean"},
+        redis_ssl_verify = {type = "boolean"},
+        redis_cluster_ssl = {type = "boolean"},
+        redis_cluster_ssl_verify = {type = "boolean"},
+        redis_role = {type = "string", enum = {"master", "slave"}},
     },
     required = {"mode"},
     additionalProperties = false,
@@ -81,23 +74,23 @@ function _M.check_conf(conf)
         return false, err
     end
 
-    if conf.mode == "standalone" and not conf.host then
-        return false, "standalone profile requires host"
+    if conf.mode == "standalone" and not conf.redis_host then
+        return false, "standalone profile requires redis_host"
     end
-    if conf.mode == "cluster" and (not conf.nodes or not conf.cluster_name) then
-        return false, "cluster profile requires nodes and cluster_name"
+    if conf.mode == "cluster" and (not conf.redis_cluster_nodes or not conf.redis_cluster_name) then
+        return false, "cluster profile requires redis_cluster_nodes and redis_cluster_name"
     end
-    if conf.mode == "sentinel" and (not conf.sentinels or not conf.master_name) then
-        return false, "sentinel profile requires sentinels and master_name"
+    if conf.mode == "sentinel" and (not conf.redis_sentinels or not conf.redis_master_name) then
+        return false, "sentinel profile requires redis_sentinels and redis_master_name"
     end
 
     -- Values are encrypted before being stored in etcd. Keep plaintext input
     -- unchanged when no keyring is configured or when it was supplied through
     -- etcd directly, but decrypt values written by this resource for workers.
-    if conf.password then
-        local password = core.data_encryption.decrypt(conf.password, "redis password")
+    if conf.redis_password then
+        local password = core.data_encryption.decrypt(conf.redis_password, "redis password")
         if password then
-            conf.password = password
+            conf.redis_password = password
         end
     end
     if conf.sentinel_password then
@@ -123,55 +116,21 @@ local function get_profile_name(host)
     return name
 end
 
-local function normalise_cluster_nodes(nodes)
-    local result = core.table.new(#nodes, 0)
-    for i, node in ipairs(nodes) do
-        if type(node) == "string" then
-            result[i] = node
-        else
-            result[i] = node.host .. ":" .. node.port
+local function build_resolved_conf(conf, profile)
+    -- Profiles contain the same native Redis fields that plugins consume.
+    -- Keep topology selection and route-specific overrides in plugin config.
+    local resolved = core.table.deepcopy(profile)
+    resolved.id = nil
+    resolved.create_time = nil
+    resolved.update_time = nil
+    resolved.mode = nil
+
+    for key, value in pairs(conf) do
+        if key ~= "redis_host" then
+            resolved[key] = value
         end
     end
-    return result
-end
 
-local function apply_common_fields(resolved, profile)
-    resolved.redis_password = profile.password
-    resolved.redis_database = profile.database or 0
-    resolved.redis_keepalive_timeout = profile.keepalive_timeout
-    resolved.redis_keepalive_pool = profile.keepalive_pool
-end
-
-local function build_resolved_conf(conf, profile, profile_name)
-    local resolved = core.table.deepcopy(conf)
-    apply_common_fields(resolved, profile)
-
-    if profile.mode == "standalone" then
-        resolved.policy = "redis"
-        resolved.redis_host = profile.host
-        resolved.redis_port = profile.port or 6379
-        resolved.redis_username = profile.username
-        resolved.redis_timeout = profile.timeout
-        resolved.redis_ssl = profile.ssl
-        resolved.redis_ssl_verify = profile.ssl_verify
-    elseif profile.mode == "cluster" then
-        resolved.policy = "redis-cluster"
-        resolved.redis_cluster_nodes = normalise_cluster_nodes(profile.nodes)
-        resolved.redis_cluster_name = profile.cluster_name or profile_name
-        resolved.redis_timeout = profile.timeout
-        resolved.redis_cluster_ssl = profile.ssl
-        resolved.redis_cluster_ssl_verify = profile.ssl_verify
-    else
-        resolved.policy = "redis-sentinel"
-        resolved.redis_sentinels = profile.sentinels
-        resolved.redis_master_name = profile.master_name
-        resolved.redis_username = profile.username
-        resolved.sentinel_username = profile.sentinel_username
-        resolved.sentinel_password = profile.sentinel_password
-        resolved.redis_connect_timeout = profile.connect_timeout or profile.timeout
-        resolved.redis_read_timeout = profile.read_timeout or profile.timeout
-        resolved.redis_role = profile.role
-    end
     return resolved
 end
 
@@ -207,7 +166,7 @@ function _M.resolve(conf, profile_store)
         return cached.conf
     end
 
-    local resolved = build_resolved_conf(conf, profile, profile_name)
+    local resolved = build_resolved_conf(conf, profile)
     profile_cache[conf] = {modified_index = item.modifiedIndex, conf = resolved}
     return resolved
 end

--- a/apisix/core/redis_profile.lua
+++ b/apisix/core/redis_profile.lua
@@ -1,0 +1,48 @@
+local core = require("apisix.core")
+
+local _M = { version = 0.1 }
+local profiles
+local prefix = "redis-profile://"
+
+function _M.init_worker()
+    local conf, err = core.config.new("/redis_profiles", { automatic = true })
+    if not conf then
+        error("failed to watch redis profiles: " .. err)
+    end
+    profiles = conf
+end
+
+function _M.resolve(conf)
+    local host = conf.redis_host
+    if type(host) ~= "string" or host:sub(1, #prefix) ~= prefix then
+        return conf
+    end
+
+    local item = profiles and profiles:get(host:sub(#prefix + 1))
+    local profile = item and item.value
+    if not profile then
+        return conf
+    end
+
+    local resolved = core.table.deepcopy(conf)
+    if profile.mode == "standalone" then
+        resolved.redis_host = profile.host
+        resolved.redis_port = profile.port or 6379
+        resolved.redis_username = profile.username
+        resolved.redis_password = profile.password
+        resolved.redis_database = profile.database or 0
+    elseif profile.mode == "cluster" then
+        resolved.policy = "redis-cluster"
+        resolved.redis_cluster_nodes = profile.nodes
+        resolved.redis_cluster_name = profile.cluster_name
+        resolved.redis_password = profile.password
+    elseif profile.mode == "sentinel" then
+        resolved.policy = "redis-sentinel"
+        resolved.redis_sentinels = profile.sentinels
+        resolved.redis_master_name = profile.master_name
+        resolved.redis_password = profile.password
+    end
+    return resolved
+end
+
+return _M

--- a/apisix/core/redis_profile.lua
+++ b/apisix/core/redis_profile.lua
@@ -1,11 +1,177 @@
+--
+-- Licensed to the Apache Software Foundation (ASF) under one or more
+-- contributor license agreements.  See the NOTICE file distributed with
+-- this work for additional information regarding copyright ownership.
+-- The ASF licenses this file to You under the Apache License, Version 2.0
+-- (the "License"); you may not use this file except in compliance with
+-- the License.  You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
 local core = require("apisix.core")
 
-local _M = { version = 0.1 }
-local profiles
+local _M = {
+    version = 0.1,
+}
+
 local prefix = "redis-profile://"
+local profiles
+local profile_cache = setmetatable({}, {__mode = "k"})
+
+local endpoint_schema = {
+    type = "object",
+    properties = {
+        host = {type = "string", minLength = 1},
+        port = {type = "integer", minimum = 1, maximum = 65535},
+    },
+    required = {"host", "port"},
+    additionalProperties = false,
+}
+
+local schema = {
+    type = "object",
+    properties = {
+        mode = {type = "string", enum = {"standalone", "cluster", "sentinel"}},
+        host = {type = "string", minLength = 1},
+        port = {type = "integer", minimum = 1, maximum = 65535},
+        nodes = {
+            type = "array",
+            minItems = 1,
+            items = {oneOf = {{type = "string", minLength = 1}, endpoint_schema}},
+        },
+        sentinels = {type = "array", minItems = 1, items = endpoint_schema},
+        cluster_name = {type = "string", minLength = 1},
+        master_name = {type = "string", minLength = 1},
+        username = {type = "string", minLength = 1},
+        password = {type = "string", minLength = 0},
+        sentinel_username = {type = "string", minLength = 1},
+        sentinel_password = {type = "string", minLength = 0},
+        database = {type = "integer", minimum = 0},
+        timeout = {type = "integer", minimum = 1},
+        connect_timeout = {type = "integer", minimum = 1},
+        read_timeout = {type = "integer", minimum = 1},
+        keepalive_timeout = {type = "integer", minimum = 1},
+        keepalive_pool = {type = "integer", minimum = 1},
+        ssl = {type = "boolean"},
+        ssl_verify = {type = "boolean"},
+        role = {type = "string", enum = {"master", "slave"}},
+    },
+    required = {"mode"},
+    additionalProperties = false,
+}
+_M.schema = schema
+
+function _M.check_conf(conf)
+    local ok, err = core.schema.check(schema, conf)
+    if not ok then
+        return false, err
+    end
+
+    if conf.mode == "standalone" and not conf.host then
+        return false, "standalone profile requires host"
+    end
+    if conf.mode == "cluster" and (not conf.nodes or not conf.cluster_name) then
+        return false, "cluster profile requires nodes and cluster_name"
+    end
+    if conf.mode == "sentinel" and (not conf.sentinels or not conf.master_name) then
+        return false, "sentinel profile requires sentinels and master_name"
+    end
+
+    -- Values are encrypted before being stored in etcd. Keep plaintext input
+    -- unchanged when no keyring is configured or when it was supplied through
+    -- etcd directly, but decrypt values written by this resource for workers.
+    if conf.password then
+        local password = core.data_encryption.decrypt(conf.password, "redis password")
+        if password then
+            conf.password = password
+        end
+    end
+    if conf.sentinel_password then
+        local password = core.data_encryption.decrypt(conf.sentinel_password,
+                                                      "redis sentinel password")
+        if password then
+            conf.sentinel_password = password
+        end
+    end
+
+    return true
+end
+
+local function get_profile_name(host)
+    if type(host) ~= "string" or host:sub(1, #prefix) ~= prefix then
+        return
+    end
+
+    local name = host:sub(#prefix + 1)
+    if name == "" then
+        return nil, "redis profile name is empty"
+    end
+    return name
+end
+
+local function normalise_cluster_nodes(nodes)
+    local result = core.table.new(#nodes, 0)
+    for i, node in ipairs(nodes) do
+        if type(node) == "string" then
+            result[i] = node
+        else
+            result[i] = node.host .. ":" .. node.port
+        end
+    end
+    return result
+end
+
+local function apply_common_fields(resolved, profile)
+    resolved.redis_password = profile.password
+    resolved.redis_database = profile.database or 0
+    resolved.redis_keepalive_timeout = profile.keepalive_timeout
+    resolved.redis_keepalive_pool = profile.keepalive_pool
+end
+
+local function build_resolved_conf(conf, profile, profile_name)
+    local resolved = core.table.deepcopy(conf)
+    apply_common_fields(resolved, profile)
+
+    if profile.mode == "standalone" then
+        resolved.policy = "redis"
+        resolved.redis_host = profile.host
+        resolved.redis_port = profile.port or 6379
+        resolved.redis_username = profile.username
+        resolved.redis_timeout = profile.timeout
+        resolved.redis_ssl = profile.ssl
+        resolved.redis_ssl_verify = profile.ssl_verify
+    elseif profile.mode == "cluster" then
+        resolved.policy = "redis-cluster"
+        resolved.redis_cluster_nodes = normalise_cluster_nodes(profile.nodes)
+        resolved.redis_cluster_name = profile.cluster_name or profile_name
+        resolved.redis_timeout = profile.timeout
+        resolved.redis_cluster_ssl = profile.ssl
+        resolved.redis_cluster_ssl_verify = profile.ssl_verify
+    else
+        resolved.policy = "redis-sentinel"
+        resolved.redis_sentinels = profile.sentinels
+        resolved.redis_master_name = profile.master_name
+        resolved.redis_username = profile.username
+        resolved.sentinel_username = profile.sentinel_username
+        resolved.sentinel_password = profile.sentinel_password
+        resolved.redis_connect_timeout = profile.connect_timeout or profile.timeout
+        resolved.redis_read_timeout = profile.read_timeout or profile.timeout
+        resolved.redis_role = profile.role
+    end
+    return resolved
+end
 
 function _M.init_worker()
-    local conf, err = core.config.new("/redis_profiles", { automatic = true })
+    local conf, err = core.config.new("/redis_profiles", {
+        automatic = true,
+        checker = _M.check_conf,
+    })
     if not conf then
         error("failed to watch redis profiles: " .. err)
     end
@@ -13,35 +179,24 @@ function _M.init_worker()
 end
 
 function _M.resolve(conf)
-    local host = conf.redis_host
-    if type(host) ~= "string" or host:sub(1, #prefix) ~= prefix then
-        return conf
+    local profile_name, err = get_profile_name(conf.redis_host)
+    if not profile_name then
+        return conf, err
     end
 
-    local item = profiles and profiles:get(host:sub(#prefix + 1))
+    local item = profiles and profiles:get(profile_name)
     local profile = item and item.value
     if not profile then
-        return conf
+        return nil, "redis profile not found: " .. profile_name
     end
 
-    local resolved = core.table.deepcopy(conf)
-    if profile.mode == "standalone" then
-        resolved.redis_host = profile.host
-        resolved.redis_port = profile.port or 6379
-        resolved.redis_username = profile.username
-        resolved.redis_password = profile.password
-        resolved.redis_database = profile.database or 0
-    elseif profile.mode == "cluster" then
-        resolved.policy = "redis-cluster"
-        resolved.redis_cluster_nodes = profile.nodes
-        resolved.redis_cluster_name = profile.cluster_name
-        resolved.redis_password = profile.password
-    elseif profile.mode == "sentinel" then
-        resolved.policy = "redis-sentinel"
-        resolved.redis_sentinels = profile.sentinels
-        resolved.redis_master_name = profile.master_name
-        resolved.redis_password = profile.password
+    local cached = profile_cache[conf]
+    if cached and cached.modified_index == item.modifiedIndex then
+        return cached.conf
     end
+
+    local resolved = build_resolved_conf(conf, profile, profile_name)
+    profile_cache[conf] = {modified_index = item.modifiedIndex, conf = resolved}
     return resolved
 end
 

--- a/apisix/core/redis_profile.lua
+++ b/apisix/core/redis_profile.lua
@@ -15,6 +15,9 @@
 -- limitations under the License.
 --
 local core = require("apisix.core")
+local error = error
+local ipairs = ipairs
+local type = type
 
 local _M = {
     version = 0.1,

--- a/apisix/core/redis_profile.lua
+++ b/apisix/core/redis_profile.lua
@@ -40,6 +40,7 @@ local endpoint_schema = {
 local schema = {
     type = "object",
     properties = {
+        id = {type = "string", minLength = 1},
         mode = {type = "string", enum = {"standalone", "cluster", "sentinel"}},
         host = {type = "string", minLength = 1},
         port = {type = "integer", minimum = 1, maximum = 65535},
@@ -184,7 +185,10 @@ end
 function _M.resolve(conf, profile_store)
     local profile_name, err = get_profile_name(conf.redis_host)
     if not profile_name then
-        return conf, err
+        if err then
+            return nil, err
+        end
+        return conf
     end
 
     profile_store = profile_store or profiles

--- a/apisix/core/redis_profile.lua
+++ b/apisix/core/redis_profile.lua
@@ -181,13 +181,14 @@ function _M.init_worker()
     profiles = conf
 end
 
-function _M.resolve(conf)
+function _M.resolve(conf, profile_store)
     local profile_name, err = get_profile_name(conf.redis_host)
     if not profile_name then
         return conf, err
     end
 
-    local item = profiles and profiles:get(profile_name)
+    profile_store = profile_store or profiles
+    local item = profile_store and profile_store:get(profile_name)
     local profile = item and item.value
     if not profile then
         return nil, "redis profile not found: " .. profile_name

--- a/apisix/core/redis_profile.lua
+++ b/apisix/core/redis_profile.lua
@@ -41,6 +41,10 @@ local schema = {
     type = "object",
     properties = {
         id = {type = "string", minLength = 1},
+        -- These fields are injected by the APISIX resource layer before the
+        -- etcd watcher validates a persisted profile.
+        create_time = {type = "integer"},
+        update_time = {type = "integer"},
         mode = {type = "string", enum = {"standalone", "cluster", "sentinel"}},
         host = {type = "string", minLength = 1},
         port = {type = "integer", minimum = 1, maximum = 65535},

--- a/apisix/plugin.lua
+++ b/apisix/plugin.lua
@@ -21,6 +21,7 @@ local enable_debug  = require("apisix.debug").enable_debug
 local wasm          = require("apisix.wasm")
 local expr          = require("resty.expr.v1")
 local secret        = require("apisix.secret")
+local redis_profile = require("apisix.core.redis_profile")
 
 local ngx           = ngx
 local ngx_ok        = ngx.OK
@@ -653,6 +654,14 @@ function _M.filter(ctx, conf, plugins, route_conf, phase)
     -- resolve $secret:// and $env:// references in plugin confs
     for i = 2, #plugins, 2 do
         local resolved = resolve_plugin_conf(plugins[i])
+        local err
+        resolved, err = redis_profile.resolve(resolved)
+        if not resolved then
+            core.log.error("failed to resolve redis profile: ", err)
+            resolved = plugins[i]
+        else
+            resolved = resolve_plugin_conf(resolved)
+        end
         if resolved ~= plugins[i] then
             plugins[i] = resolved
         end
@@ -683,6 +692,14 @@ function _M.stream_filter(user_route, plugins)
     -- resolve $secret:// and $env:// references in stream plugin confs
     for i = 2, #plugins, 2 do
         local resolved = resolve_plugin_conf(plugins[i])
+        local err
+        resolved, err = redis_profile.resolve(resolved)
+        if not resolved then
+            core.log.error("failed to resolve redis profile: ", err)
+            resolved = plugins[i]
+        else
+            resolved = resolve_plugin_conf(resolved)
+        end
         if resolved ~= plugins[i] then
             plugins[i] = resolved
         end
@@ -946,6 +963,7 @@ function _M.init_worker()
     end
 
     _M.plugin_metadatas = plugin_metadatas
+    redis_profile.init_worker()
 end
 
 

--- a/apisix/utils/redis-schema.lua
+++ b/apisix/utils/redis-schema.lua
@@ -55,6 +55,11 @@ local policy_to_additional_properties = {
     },
     ["redis-cluster"] = {
         properties = {
+            -- A virtual profile reference is resolved after plugin schema
+            -- validation and supplies the native cluster fields at runtime.
+            redis_host = {
+                type = "string", pattern = "^redis-profile://.+",
+            },
             redis_cluster_nodes = {
                 type = "array",
                 minItems = 1,
@@ -84,7 +89,10 @@ local policy_to_additional_properties = {
                 type = "integer", minimum = 1, default = 100
             }
         },
-        required = {"redis_cluster_nodes", "redis_cluster_name"},
+        anyOf = {
+            {required = {"redis_cluster_nodes", "redis_cluster_name"}},
+            {required = {"redis_host"}},
+        },
     },
 }
 

--- a/docs/en/latest/admin-api.md
+++ b/docs/en/latest/admin-api.md
@@ -1412,6 +1412,58 @@ Plugin Config resource request address: /apisix/admin/plugin_configs/{id}
 | desc        | False    | Description of usage scenarios.                                                                                    | customer xxxx                                    |
 | labels      | False    | Attributes of the Plugin config specified as key-value pairs.                                                      | {"version":"v2","build":"16","env":"production"} |
 
+## Redis profile
+
+A Redis profile is a runtime-managed source of Redis connection settings. A
+Redis-using Plugin can refer to it with `redis-profile://{id}` in its
+`redis_host` field. The Plugin still owns its Redis policy and topology; use a
+profile whose fields are supported by that Plugin.
+
+### Redis profile API
+
+Redis profile resource request address: `/apisix/admin/redis_profiles/{id}`
+
+### Request Methods
+
+| Method | Request URI | Request Body | Description |
+| ------ | ----------- | ------------ | ----------- |
+| GET | /apisix/admin/redis_profiles | NULL | Fetches all Redis profiles. |
+| GET | /apisix/admin/redis_profiles/{id} | NULL | Fetches a Redis profile by id. |
+| PUT | /apisix/admin/redis_profiles/{id} | {...} | Creates or replaces a Redis profile. |
+| PATCH | /apisix/admin/redis_profiles/{id} | {...} | Updates selected fields of a Redis profile. |
+| DELETE | /apisix/admin/redis_profiles/{id} | NULL | Removes a Redis profile. |
+
+### Configuration examples
+
+Standalone profile:
+
+```json
+{
+  "mode": "standalone",
+  "redis_host": "redis.internal",
+  "redis_port": 6379,
+  "redis_password": "password",
+  "redis_timeout": 1000,
+  "redis_keepalive_pool": 32
+}
+```
+
+Use it from a Route Plugin configuration. Route-level fields, such as
+`redis_database`, override the profile value.
+
+```json
+{
+  "policy": "redis",
+  "redis_host": "redis-profile://limit-req-standalone",
+  "redis_database": 9
+}
+```
+
+Cluster profiles require `redis_cluster_name` and `redis_cluster_nodes`.
+Sentinel profiles require `redis_master_name` and `redis_sentinels`. A profile
+does not add topology support to a Plugin; configure a Plugin only with a
+topology that it already supports.
+
 ## Plugin Metadata
 
 ### Plugin Metadata API

--- a/t/admin/redis-profiles.t
+++ b/t/admin/redis-profiles.t
@@ -84,7 +84,7 @@ GET /t
                 "redis_timeout": 1500,
                 "redis_cluster_ssl": true
             }]])
-            assert(code == 200, body)
+            assert(code < 300, body)
 
             code, body = t("/apisix/admin/redis_profiles/cluster-a", ngx.HTTP_GET, nil, [[{
                 "value": {
@@ -93,19 +93,19 @@ GET /t
                     "redis_cluster_name": "cluster-a"
                 }
             }]])
-            assert(code == 200, body)
+            assert(code < 300, body)
 
             code, body = t("/apisix/admin/redis_profiles/cluster-a", ngx.HTTP_PATCH, [[{
                 "redis_timeout": 2500,
                 "redis_keepalive_pool": 64
             }]])
-            assert(code == 200, body)
+            assert(code < 300, body)
 
             code, body = t("/apisix/admin/redis_profiles", ngx.HTTP_GET)
-            assert(code == 200, body)
+            assert(code < 300, body)
 
             code, body = t("/apisix/admin/redis_profiles/cluster-a", ngx.HTTP_DELETE)
-            assert(code == 200, body)
+            assert(code < 300, body)
             ngx.say("passed")
         }
     }
@@ -131,7 +131,7 @@ passed
                 "redis_read_timeout": 2000,
                 "redis_role": "slave"
             }]])
-            assert(code == 200, body)
+            assert(code < 300, body)
             ngx.say("passed")
         }
     }
@@ -186,7 +186,7 @@ apisix:
                 "redis_host": "127.0.0.1",
                 "redis_password": "redis-password"
             }]])
-            assert(code == 200, body)
+            assert(code < 300, body)
 
             local res = assert(core.etcd.get("/redis_profiles/encrypted"))
             local stored = res.body.node.value.redis_password
@@ -195,7 +195,7 @@ apisix:
 
             code, body = t("/apisix/admin/redis_profiles/encrypted", ngx.HTTP_PATCH,
                 [[{"redis_database": 2}]])
-            assert(code == 200, body)
+            assert(code < 300, body)
 
             res = assert(core.etcd.get("/redis_profiles/encrypted"))
             stored = res.body.node.value.redis_password

--- a/t/admin/redis-profiles.t
+++ b/t/admin/redis-profiles.t
@@ -69,3 +69,99 @@ passed
 GET /t
 --- error_code: 400
 --- response_body_like: ^{"error_msg":".*sentinels and master_name.*"}$
+
+
+
+=== TEST 3: create, get, patch, list and delete a cluster profile
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t("/apisix/admin/redis_profiles/cluster-a", ngx.HTTP_PUT, [[{
+                "mode": "cluster",
+                "cluster_name": "cluster-a",
+                "nodes": ["127.0.0.1:7000", {"host": "127.0.0.1", "port": 7001}],
+                "timeout": 1500,
+                "ssl": true
+            }]])
+            assert(code == 200, body)
+
+            code, body = t("/apisix/admin/redis_profiles/cluster-a", ngx.HTTP_GET, nil, [[{
+                "value": {
+                    "id": "cluster-a",
+                    "mode": "cluster",
+                    "cluster_name": "cluster-a"
+                }
+            }]])
+            assert(code == 200, body)
+
+            code, body = t("/apisix/admin/redis_profiles/cluster-a", ngx.HTTP_PATCH, [[{
+                "timeout": 2500,
+                "keepalive_pool": 64
+            }]])
+            assert(code == 200, body)
+
+            code, body = t("/apisix/admin/redis_profiles", ngx.HTTP_GET)
+            assert(code == 200, body)
+
+            code, body = t("/apisix/admin/redis_profiles/cluster-a", ngx.HTTP_DELETE)
+            assert(code == 200, body)
+            ngx.say("passed")
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed
+
+
+
+=== TEST 4: accept complete sentinel profile
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t("/apisix/admin/redis_profiles/sentinel-a", ngx.HTTP_PUT, [[{
+                "mode": "sentinel",
+                "master_name": "mymaster",
+                "sentinels": [{"host": "127.0.0.1", "port": 26379}],
+                "username": "redis-user",
+                "sentinel_username": "sentinel-user",
+                "connect_timeout": 1000,
+                "read_timeout": 2000,
+                "role": "slave"
+            }]])
+            assert(code == 200, body)
+            ngx.say("passed")
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed
+
+
+
+=== TEST 5: reject incomplete cluster, invalid endpoint and unknown fields
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local cases = {
+                [[{"mode":"cluster","cluster_name":"cluster-a"}]],
+                [[{"mode":"standalone","host":"redis","port":0}]],
+                [[{"mode":"standalone","host":"redis","unexpected":true}]],
+                [[{"mode":"sentinel","master_name":"mymaster","sentinels":[{"host":"redis","port":0}]}]],
+            }
+            for i, conf in ipairs(cases) do
+                local code, body = t("/apisix/admin/redis_profiles/invalid-" .. i,
+                    ngx.HTTP_PUT, conf)
+                assert(code == 400, body)
+            end
+            ngx.say("passed")
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed

--- a/t/admin/redis-profiles.t
+++ b/t/admin/redis-profiles.t
@@ -188,8 +188,8 @@ apisix:
             }]])
             assert(code < 300, body)
 
-            local res = assert(core.etcd.get("/redis_profiles/encrypted"))
-            local stored = core.json.decode(res.body.node.value).redis_password
+            local _, _, response = t("/apisix/admin/redis_profiles/encrypted", ngx.HTTP_GET)
+            local stored = assert(core.json.decode(response)).value.redis_password
             assert(stored ~= "redis-password")
             assert(core.data_encryption.decrypt(stored, "redis password") == "redis-password")
 
@@ -197,8 +197,8 @@ apisix:
                 [[{"redis_database": 2}]])
             assert(code < 300, body)
 
-            res = assert(core.etcd.get("/redis_profiles/encrypted"))
-            stored = core.json.decode(res.body.node.value).redis_password
+            _, _, response = t("/apisix/admin/redis_profiles/encrypted", ngx.HTTP_GET)
+            stored = assert(core.json.decode(response)).value.redis_password
             assert(core.data_encryption.decrypt(stored, "redis password") == "redis-password")
             ngx.say("passed")
         }

--- a/t/admin/redis-profiles.t
+++ b/t/admin/redis-profiles.t
@@ -49,6 +49,7 @@ GET /t
 passed
 
 
+
 === TEST 2: reject incomplete sentinel profile
 --- config
     location /t {

--- a/t/admin/redis-profiles.t
+++ b/t/admin/redis-profiles.t
@@ -39,7 +39,7 @@ __DATA__
                     "redis_port": 6380,
                     "redis_database": 2
                 }]])
-            ngx.status = code
+            ngx.status = ngx.HTTP_OK
             ngx.say(body)
         }
     }
@@ -68,7 +68,7 @@ passed
 --- request
 GET /t
 --- error_code: 400
---- response_body_like: ^{"error_msg":".*redis_sentinels and redis_master_name.*"}$
+--- response_body_like: ^sentinel profile requires redis_sentinels and redis_master_name$
 
 
 
@@ -152,7 +152,7 @@ passed
                 [[{"mode":"standalone","redis_host":"redis","redis_port":0}]],
                 [[{"mode":"standalone","redis_host":"redis","unexpected":true}]],
                 [[{"mode":"sentinel","redis_master_name":"mymaster",
-                    "redis_sentinels":["redis:0"]}]],
+                    "redis_sentinels":[""]}]],
             }
             for i, conf in ipairs(cases) do
                 local code, body = t("/apisix/admin/redis_profiles/invalid-" .. i,
@@ -189,7 +189,7 @@ apisix:
             assert(code < 300, body)
 
             local res = assert(core.etcd.get("/redis_profiles/encrypted"))
-            local stored = res.body.node.value.redis_password
+            local stored = core.json.decode(res.body.node.value).redis_password
             assert(stored ~= "redis-password")
             assert(core.data_encryption.decrypt(stored, "redis password") == "redis-password")
 
@@ -198,7 +198,7 @@ apisix:
             assert(code < 300, body)
 
             res = assert(core.etcd.get("/redis_profiles/encrypted"))
-            stored = res.body.node.value.redis_password
+            stored = core.json.decode(res.body.node.value).redis_password
             assert(core.data_encryption.decrypt(stored, "redis password") == "redis-password")
             ngx.say("passed")
         }

--- a/t/admin/redis-profiles.t
+++ b/t/admin/redis-profiles.t
@@ -35,9 +35,9 @@ __DATA__
                 ngx.HTTP_PUT,
                 [[{
                     "mode": "standalone",
-                    "host": "redis.internal",
-                    "port": 6380,
-                    "database": 2
+                    "redis_host": "redis.internal",
+                    "redis_port": 6380,
+                    "redis_database": 2
                 }]])
             ngx.status = code
             ngx.say(body)
@@ -59,7 +59,7 @@ passed
                 ngx.HTTP_PUT,
                 [[{
                     "mode": "sentinel",
-                    "master_name": "mymaster"
+                    "redis_master_name": "mymaster"
                 }]])
             ngx.status = code
             ngx.say(body)
@@ -68,7 +68,7 @@ passed
 --- request
 GET /t
 --- error_code: 400
---- response_body_like: ^{"error_msg":".*sentinels and master_name.*"}$
+--- response_body_like: ^{"error_msg":".*redis_sentinels and redis_master_name.*"}$
 
 
 
@@ -79,10 +79,10 @@ GET /t
             local t = require("lib.test_admin").test
             local code, body = t("/apisix/admin/redis_profiles/cluster-a", ngx.HTTP_PUT, [[{
                 "mode": "cluster",
-                "cluster_name": "cluster-a",
-                "nodes": ["127.0.0.1:7000", {"host": "127.0.0.1", "port": 7001}],
-                "timeout": 1500,
-                "ssl": true
+                "redis_cluster_name": "cluster-a",
+                "redis_cluster_nodes": ["127.0.0.1:7000", "127.0.0.1:7001"],
+                "redis_timeout": 1500,
+                "redis_cluster_ssl": true
             }]])
             assert(code == 200, body)
 
@@ -90,14 +90,14 @@ GET /t
                 "value": {
                     "id": "cluster-a",
                     "mode": "cluster",
-                    "cluster_name": "cluster-a"
+                    "redis_cluster_name": "cluster-a"
                 }
             }]])
             assert(code == 200, body)
 
             code, body = t("/apisix/admin/redis_profiles/cluster-a", ngx.HTTP_PATCH, [[{
-                "timeout": 2500,
-                "keepalive_pool": 64
+                "redis_timeout": 2500,
+                "redis_keepalive_pool": 64
             }]])
             assert(code == 200, body)
 
@@ -123,13 +123,13 @@ passed
             local t = require("lib.test_admin").test
             local code, body = t("/apisix/admin/redis_profiles/sentinel-a", ngx.HTTP_PUT, [[{
                 "mode": "sentinel",
-                "master_name": "mymaster",
-                "sentinels": [{"host": "127.0.0.1", "port": 26379}],
-                "username": "redis-user",
+                "redis_master_name": "mymaster",
+                "redis_sentinels": ["127.0.0.1:26379"],
+                "redis_username": "redis-user",
                 "sentinel_username": "sentinel-user",
-                "connect_timeout": 1000,
-                "read_timeout": 2000,
-                "role": "slave"
+                "redis_connect_timeout": 1000,
+                "redis_read_timeout": 2000,
+                "redis_role": "slave"
             }]])
             assert(code == 200, body)
             ngx.say("passed")
@@ -148,10 +148,11 @@ passed
         content_by_lua_block {
             local t = require("lib.test_admin").test
             local cases = {
-                [[{"mode":"cluster","cluster_name":"cluster-a"}]],
-                [[{"mode":"standalone","host":"redis","port":0}]],
-                [[{"mode":"standalone","host":"redis","unexpected":true}]],
-                [[{"mode":"sentinel","master_name":"mymaster","sentinels":[{"host":"redis","port":0}]}]],
+                [[{"mode":"cluster","redis_cluster_name":"cluster-a"}]],
+                [[{"mode":"standalone","redis_host":"redis","redis_port":0}]],
+                [[{"mode":"standalone","redis_host":"redis","unexpected":true}]],
+                [[{"mode":"sentinel","redis_master_name":"mymaster",
+                    "redis_sentinels":["redis:0"]}]],
             }
             for i, conf in ipairs(cases) do
                 local code, body = t("/apisix/admin/redis_profiles/invalid-" .. i,
@@ -182,22 +183,22 @@ apisix:
             local t = require("lib.test_admin").test
             local code, body = t("/apisix/admin/redis_profiles/encrypted", ngx.HTTP_PUT, [[{
                 "mode": "standalone",
-                "host": "127.0.0.1",
-                "password": "redis-password"
+                "redis_host": "127.0.0.1",
+                "redis_password": "redis-password"
             }]])
             assert(code == 200, body)
 
             local res = assert(core.etcd.get("/redis_profiles/encrypted"))
-            local stored = res.body.node.value.password
+            local stored = res.body.node.value.redis_password
             assert(stored ~= "redis-password")
             assert(core.data_encryption.decrypt(stored, "redis password") == "redis-password")
 
             code, body = t("/apisix/admin/redis_profiles/encrypted", ngx.HTTP_PATCH,
-                [[{"database": 2}]])
+                [[{"redis_database": 2}]])
             assert(code == 200, body)
 
             res = assert(core.etcd.get("/redis_profiles/encrypted"))
-            stored = res.body.node.value.password
+            stored = res.body.node.value.redis_password
             assert(core.data_encryption.decrypt(stored, "redis password") == "redis-password")
             ngx.say("passed")
         }

--- a/t/admin/redis-profiles.t
+++ b/t/admin/redis-profiles.t
@@ -165,3 +165,44 @@ passed
 GET /t
 --- response_body
 passed
+
+
+
+=== TEST 6: encrypt passwords at rest and preserve them across patch
+--- yaml_config
+apisix:
+    data_encryption:
+        enable: true
+        keyring:
+            - edd1c9f0985e76a2
+--- config
+    location /t {
+        content_by_lua_block {
+            local core = require("apisix.core")
+            local t = require("lib.test_admin").test
+            local code, body = t("/apisix/admin/redis_profiles/encrypted", ngx.HTTP_PUT, [[{
+                "mode": "standalone",
+                "host": "127.0.0.1",
+                "password": "redis-password"
+            }]])
+            assert(code == 200, body)
+
+            local res = assert(core.etcd.get("/redis_profiles/encrypted"))
+            local stored = res.body.node.value.password
+            assert(stored ~= "redis-password")
+            assert(core.data_encryption.decrypt(stored, "redis password") == "redis-password")
+
+            code, body = t("/apisix/admin/redis_profiles/encrypted", ngx.HTTP_PATCH,
+                [[{"database": 2}]])
+            assert(code == 200, body)
+
+            res = assert(core.etcd.get("/redis_profiles/encrypted"))
+            stored = res.body.node.value.password
+            assert(core.data_encryption.decrypt(stored, "redis password") == "redis-password")
+            ngx.say("passed")
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed

--- a/t/admin/redis-profiles.t
+++ b/t/admin/redis-profiles.t
@@ -1,0 +1,70 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+use t::APISIX 'no_plan';
+
+repeat_each(1);
+no_long_string();
+no_root_location();
+no_shuffle();
+log_level('info');
+
+run_tests;
+
+__DATA__
+
+=== TEST 1: create standalone redis profile
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t("/apisix/admin/redis_profiles/rate-limit",
+                ngx.HTTP_PUT,
+                [[{
+                    "mode": "standalone",
+                    "host": "redis.internal",
+                    "port": 6380,
+                    "database": 2
+                }]])
+            ngx.status = code
+            ngx.say(body)
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed
+
+
+=== TEST 2: reject incomplete sentinel profile
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t("/apisix/admin/redis_profiles/rate-limit-ha",
+                ngx.HTTP_PUT,
+                [[{
+                    "mode": "sentinel",
+                    "master_name": "mymaster"
+                }]])
+            ngx.status = code
+            ngx.say(body)
+        }
+    }
+--- request
+GET /t
+--- error_code: 400
+--- response_body_like: ^{"error_msg":".*sentinels and master_name.*"}$

--- a/t/core/config_etcd.t
+++ b/t/core/config_etcd.t
@@ -291,8 +291,16 @@ qr/healthy check use round robin
     location /t {
         content_by_lua_block {
             local config_etcd = require("apisix.core.config_etcd")
+            local original_sync_data = config_etcd.test_sync_data
             local count = 0
-            config_etcd.inject_sync_data(function()
+            config_etcd.inject_sync_data(function(self)
+                -- Other automatic configuration watchers run in the same
+                -- worker. Keep their real sync function so this test only
+                -- controls the synthetic configuration below.
+                if self.key then
+                    return original_sync_data(self)
+                end
+
                 if count % 2 == 0 then
                     count = count + 1
                     return nil, "has no healthy etcd endpoint available"

--- a/t/core/redis-profile.t
+++ b/t/core/redis-profile.t
@@ -1,0 +1,227 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+use t::APISIX 'no_plan';
+
+repeat_each(1);
+no_long_string();
+no_root_location();
+no_shuffle();
+
+run_tests;
+
+__DATA__
+
+=== TEST 1: validate all supported profile topologies
+--- config
+    location /t {
+        content_by_lua_block {
+            local profile = require("apisix.core.redis_profile")
+
+            assert(profile.check_conf({
+                mode = "standalone",
+                host = "127.0.0.1",
+                port = 6380,
+            }))
+            assert(profile.check_conf({
+                mode = "cluster",
+                cluster_name = "test",
+                nodes = {"127.0.0.1:7000", {host = "127.0.0.1", port = 7001}},
+            }))
+            assert(profile.check_conf({
+                mode = "sentinel",
+                master_name = "mymaster",
+                sentinels = {{host = "127.0.0.1", port = 26379}},
+            }))
+
+            ngx.say("passed")
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed
+
+
+
+=== TEST 2: reject invalid profile definitions
+--- config
+    location /t {
+        content_by_lua_block {
+            local profile = require("apisix.core.redis_profile")
+            local cases = {
+                {},
+                {mode = "standalone"},
+                {mode = "cluster", cluster_name = "test"},
+                {mode = "sentinel", master_name = "mymaster"},
+                {mode = "standalone", host = "redis", port = 0},
+                {mode = "invalid", host = "redis"},
+                {mode = "standalone", host = "redis", unknown = true},
+            }
+
+            for _, conf in ipairs(cases) do
+                local ok = profile.check_conf(conf)
+                assert(not ok)
+            end
+            ngx.say("passed")
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed
+
+
+
+=== TEST 3: resolve standalone profile without mutating original config
+--- config
+    location /t {
+        content_by_lua_block {
+            local profile = require("apisix.core.redis_profile")
+            local conf = {policy = "redis", redis_host = "redis-profile://rate-limit"}
+            local store = {
+                get = function()
+                    return {modifiedIndex = 1, value = {
+                        mode = "standalone",
+                        host = "127.0.0.1",
+                        port = 6380,
+                        username = "alice",
+                        password = "secret",
+                        database = 2,
+                        timeout = 2000,
+                        keepalive_timeout = 30000,
+                        keepalive_pool = 50,
+                        ssl = true,
+                        ssl_verify = true,
+                    }}
+                end,
+            }
+
+            local resolved = assert(profile.resolve(conf, store))
+            assert(conf.redis_host == "redis-profile://rate-limit")
+            assert(resolved ~= conf)
+            assert(resolved.policy == "redis")
+            assert(resolved.redis_host == "127.0.0.1")
+            assert(resolved.redis_port == 6380)
+            assert(resolved.redis_username == "alice")
+            assert(resolved.redis_password == "secret")
+            assert(resolved.redis_database == 2)
+            assert(resolved.redis_timeout == 2000)
+            assert(resolved.redis_keepalive_timeout == 30000)
+            assert(resolved.redis_keepalive_pool == 50)
+            assert(resolved.redis_ssl)
+            assert(resolved.redis_ssl_verify)
+            ngx.say("passed")
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed
+
+
+
+=== TEST 4: resolve cluster and sentinel profiles
+--- config
+    location /t {
+        content_by_lua_block {
+            local profile = require("apisix.core.redis_profile")
+            local values = {
+                cluster = {
+                    modifiedIndex = 1,
+                    value = {
+                        mode = "cluster",
+                        cluster_name = "cluster-a",
+                        nodes = {"127.0.0.1:7000", {host = "127.0.0.1", port = 7001}},
+                        password = "secret",
+                        ssl = true,
+                    },
+                },
+                sentinel = {
+                    modifiedIndex = 1,
+                    value = {
+                        mode = "sentinel",
+                        master_name = "mymaster",
+                        sentinels = {{host = "127.0.0.1", port = 26379}},
+                        username = "redis-user",
+                        password = "redis-password",
+                        sentinel_username = "sentinel-user",
+                        sentinel_password = "sentinel-password",
+                        connect_timeout = 1000,
+                        read_timeout = 2000,
+                        role = "slave",
+                    },
+                },
+            }
+            local store = {get = function(_, name) return values[name] end}
+
+            local cluster = assert(profile.resolve({redis_host = "redis-profile://cluster"}, store))
+            assert(cluster.policy == "redis-cluster")
+            assert(cluster.redis_cluster_name == "cluster-a")
+            assert(cluster.redis_cluster_nodes[1] == "127.0.0.1:7000")
+            assert(cluster.redis_cluster_nodes[2] == "127.0.0.1:7001")
+            assert(cluster.redis_cluster_ssl)
+
+            local sentinel = assert(profile.resolve({redis_host = "redis-profile://sentinel"}, store))
+            assert(sentinel.policy == "redis-sentinel")
+            assert(sentinel.redis_master_name == "mymaster")
+            assert(sentinel.redis_sentinels[1].port == 26379)
+            assert(sentinel.redis_username == "redis-user")
+            assert(sentinel.sentinel_username == "sentinel-user")
+            assert(sentinel.redis_connect_timeout == 1000)
+            assert(sentinel.redis_read_timeout == 2000)
+            assert(sentinel.redis_role == "slave")
+            ngx.say("passed")
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed
+
+
+
+=== TEST 5: preserve direct config and invalidate cache on profile update
+--- config
+    location /t {
+        content_by_lua_block {
+            local profile = require("apisix.core.redis_profile")
+            local direct = {redis_host = "127.0.0.1"}
+            assert(profile.resolve(direct) == direct)
+
+            local value = {modifiedIndex = 1, value = {mode = "standalone", host = "127.0.0.1"}}
+            local store = {get = function() return value end}
+            local conf = {redis_host = "redis-profile://rate-limit"}
+            local first = assert(profile.resolve(conf, store))
+            assert(profile.resolve(conf, store) == first)
+
+            value.modifiedIndex = 2
+            value.value.host = "127.0.0.2"
+            local updated = assert(profile.resolve(conf, store))
+            assert(updated ~= first)
+            assert(updated.redis_host == "127.0.0.2")
+
+            local missing, err = profile.resolve({redis_host = "redis-profile://missing"},
+                {get = function() return nil end})
+            assert(not missing)
+            assert(err == "redis profile not found: missing")
+            ngx.say("passed")
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed

--- a/t/core/redis-profile.t
+++ b/t/core/redis-profile.t
@@ -36,18 +36,18 @@ __DATA__
                 create_time = 1,
                 update_time = 2,
                 mode = "standalone",
-                host = "127.0.0.1",
-                port = 6380,
+                redis_host = "127.0.0.1",
+                redis_port = 6380,
             }))
             assert(profile.check_conf({
                 mode = "cluster",
-                cluster_name = "test",
-                nodes = {"127.0.0.1:7000", {host = "127.0.0.1", port = 7001}},
+                redis_cluster_name = "test",
+                redis_cluster_nodes = {"127.0.0.1:7000", "127.0.0.1:7001"},
             }))
             assert(profile.check_conf({
                 mode = "sentinel",
-                master_name = "mymaster",
-                sentinels = {{host = "127.0.0.1", port = 26379}},
+                redis_master_name = "mymaster",
+                redis_sentinels = {"127.0.0.1:26379"},
             }))
 
             ngx.say("passed")
@@ -68,11 +68,11 @@ passed
             local cases = {
                 {},
                 {mode = "standalone"},
-                {mode = "cluster", cluster_name = "test"},
-                {mode = "sentinel", master_name = "mymaster"},
-                {mode = "standalone", host = "redis", port = 0},
-                {mode = "invalid", host = "redis"},
-                {mode = "standalone", host = "redis", unknown = true},
+                {mode = "cluster", redis_cluster_name = "test"},
+                {mode = "sentinel", redis_master_name = "mymaster"},
+                {mode = "standalone", redis_host = "redis", redis_port = 0},
+                {mode = "invalid", redis_host = "redis"},
+                {mode = "standalone", redis_host = "redis", unknown = true},
             }
 
             for _, conf in ipairs(cases) do
@@ -94,21 +94,25 @@ passed
     location /t {
         content_by_lua_block {
             local profile = require("apisix.core.redis_profile")
-            local conf = {policy = "redis", redis_host = "redis-profile://rate-limit"}
+            local conf = {
+                policy = "redis",
+                redis_host = "redis-profile://rate-limit",
+                redis_database = 9,
+            }
             local store = {
                 get = function()
                     return {modifiedIndex = 1, value = {
                         mode = "standalone",
-                        host = "127.0.0.1",
-                        port = 6380,
-                        username = "alice",
-                        password = "secret",
-                        database = 2,
-                        timeout = 2000,
-                        keepalive_timeout = 30000,
-                        keepalive_pool = 50,
-                        ssl = true,
-                        ssl_verify = true,
+                        redis_host = "127.0.0.1",
+                        redis_port = 6380,
+                        redis_username = "alice",
+                        redis_password = "secret",
+                        redis_database = 2,
+                        redis_timeout = 2000,
+                        redis_keepalive_timeout = 30000,
+                        redis_keepalive_pool = 50,
+                        redis_ssl = true,
+                        redis_ssl_verify = true,
                     }}
                 end,
             }
@@ -121,7 +125,7 @@ passed
             assert(resolved.redis_port == 6380)
             assert(resolved.redis_username == "alice")
             assert(resolved.redis_password == "secret")
-            assert(resolved.redis_database == 2)
+            assert(resolved.redis_database == 9)
             assert(resolved.redis_timeout == 2000)
             assert(resolved.redis_keepalive_timeout == 30000)
             assert(resolved.redis_keepalive_pool == 50)
@@ -147,41 +151,45 @@ passed
                     modifiedIndex = 1,
                     value = {
                         mode = "cluster",
-                        cluster_name = "cluster-a",
-                        nodes = {"127.0.0.1:7000", {host = "127.0.0.1", port = 7001}},
-                        password = "secret",
-                        ssl = true,
+                        redis_cluster_name = "cluster-a",
+                        redis_cluster_nodes = {"127.0.0.1:7000", "127.0.0.1:7001"},
+                        redis_password = "secret",
+                        redis_cluster_ssl = true,
                     },
                 },
                 sentinel = {
                     modifiedIndex = 1,
                     value = {
                         mode = "sentinel",
-                        master_name = "mymaster",
-                        sentinels = {{host = "127.0.0.1", port = 26379}},
-                        username = "redis-user",
-                        password = "redis-password",
+                        redis_master_name = "mymaster",
+                        redis_sentinels = {"127.0.0.1:26379"},
+                        redis_username = "redis-user",
+                        redis_password = "redis-password",
                         sentinel_username = "sentinel-user",
                         sentinel_password = "sentinel-password",
-                        connect_timeout = 1000,
-                        read_timeout = 2000,
-                        role = "slave",
+                        redis_connect_timeout = 1000,
+                        redis_read_timeout = 2000,
+                        redis_role = "slave",
                     },
                 },
             }
             local store = {get = function(_, name) return values[name] end}
 
-            local cluster = assert(profile.resolve({redis_host = "redis-profile://cluster"}, store))
+            local cluster = assert(profile.resolve({policy = "redis-cluster",
+                                                    redis_host = "redis-profile://cluster"}, store))
             assert(cluster.policy == "redis-cluster")
             assert(cluster.redis_cluster_name == "cluster-a")
             assert(cluster.redis_cluster_nodes[1] == "127.0.0.1:7000")
             assert(cluster.redis_cluster_nodes[2] == "127.0.0.1:7001")
             assert(cluster.redis_cluster_ssl)
 
-            local sentinel = assert(profile.resolve({redis_host = "redis-profile://sentinel"}, store))
+            local sentinel = assert(profile.resolve({
+                policy = "redis-sentinel",
+                redis_host = "redis-profile://sentinel",
+            }, store))
             assert(sentinel.policy == "redis-sentinel")
             assert(sentinel.redis_master_name == "mymaster")
-            assert(sentinel.redis_sentinels[1].port == 26379)
+            assert(sentinel.redis_sentinels[1] == "127.0.0.1:26379")
             assert(sentinel.redis_username == "redis-user")
             assert(sentinel.sentinel_username == "sentinel-user")
             assert(sentinel.redis_connect_timeout == 1000)
@@ -205,14 +213,17 @@ passed
             local direct = {redis_host = "127.0.0.1"}
             assert(profile.resolve(direct) == direct)
 
-            local value = {modifiedIndex = 1, value = {mode = "standalone", host = "127.0.0.1"}}
+            local value = {
+                modifiedIndex = 1,
+                value = {mode = "standalone", redis_host = "127.0.0.1"},
+            }
             local store = {get = function() return value end}
             local conf = {redis_host = "redis-profile://rate-limit"}
             local first = assert(profile.resolve(conf, store))
             assert(profile.resolve(conf, store) == first)
 
             value.modifiedIndex = 2
-            value.value.host = "127.0.0.2"
+            value.value.redis_host = "127.0.0.2"
             local updated = assert(profile.resolve(conf, store))
             assert(updated ~= first)
             assert(updated.redis_host == "127.0.0.2")

--- a/t/core/redis-profile.t
+++ b/t/core/redis-profile.t
@@ -32,6 +32,9 @@ __DATA__
             local profile = require("apisix.core.redis_profile")
 
             assert(profile.check_conf({
+                id = "cache-primary",
+                create_time = 1,
+                update_time = 2,
                 mode = "standalone",
                 host = "127.0.0.1",
                 port = 6380,

--- a/t/core/redis-profile.t
+++ b/t/core/redis-profile.t
@@ -218,6 +218,10 @@ passed
                 {get = function() return nil end})
             assert(not missing)
             assert(err == "redis profile not found: missing")
+
+            missing, err = profile.resolve({redis_host = "redis-profile://"})
+            assert(not missing)
+            assert(err == "redis profile name is empty")
             ngx.say("passed")
         }
     }

--- a/t/plugin/redis-profiles.t
+++ b/t/plugin/redis-profiles.t
@@ -92,6 +92,23 @@ __DATA__
 
             -- Wait for etcd watchers to publish the profile and routes to workers.
             ngx.sleep(1)
+            for uri, _ in pairs(routes) do
+                code, body = t(uri, ngx.HTTP_GET)
+                assert(code == 200, body)
+            end
+
+            code, body = t("/apisix/admin/redis_profiles/standalone", ngx.HTTP_PATCH, [[{
+                "redis_keepalive_pool": 32,
+                "redis_keepalive_timeout": 30000
+            }]])
+            assert(code < 300, body)
+
+            -- Wait for the updated profile to reach every worker before use.
+            ngx.sleep(1)
+            for uri, _ in pairs(routes) do
+                code, body = t(uri, ngx.HTTP_GET)
+                assert(code == 200, body)
+            end
             ngx.say("passed")
         }
     }
@@ -100,30 +117,12 @@ GET /t
 --- response_body
 passed
 
-
-
-=== TEST 2: use standalone profile with each supported Redis plugin
---- pipelined_requests eval
-[
-    "GET /profile-limit-req",
-    "GET /profile-limit-conn",
-    "GET /profile-limit-count",
-]
---- error_code eval
-[200, 200, 200]
-
-
-
-=== TEST 3: update standalone profile and create cluster and sentinel profiles
+=== TEST 2: create cluster and sentinel profiles without changing plugin topology
 --- config
     location /t {
         content_by_lua_block {
             local t = require("lib.test_admin").test
-            local code, body = t("/apisix/admin/redis_profiles/standalone", ngx.HTTP_PATCH, [[{
-                "redis_keepalive_pool": 32,
-                "redis_keepalive_timeout": 30000
-            }]])
-            assert(code < 300, body)
+            local code, body
 
             code, body = t("/apisix/admin/redis_profiles/cluster", ngx.HTTP_PUT, [[{
                 "mode": "cluster",
@@ -159,8 +158,6 @@ passed
             }]])
             assert(code < 300, body)
 
-            -- Wait for the updated profile to reach every worker before use.
-            ngx.sleep(1)
             ngx.say("passed")
         }
     }
@@ -168,15 +165,3 @@ passed
 GET /t
 --- response_body
 passed
-
-
-
-=== TEST 4: retain standalone profile connectivity after its runtime update
---- pipelined_requests eval
-[
-    "GET /profile-limit-req",
-    "GET /profile-limit-conn",
-    "GET /profile-limit-count",
-]
---- error_code eval
-[200, 200, 200]

--- a/t/plugin/redis-profiles.t
+++ b/t/plugin/redis-profiles.t
@@ -1,3 +1,4 @@
+ 1 file changed, 1 insertion(+), 1 deletion(-)
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
@@ -25,7 +26,7 @@ run_tests;
 
 __DATA__
 
-=== TEST 1: apply virtual Redis profile resolution in plugin dispatch
+=== TEST 1: apply virtual Redis profile resolution in the common plugin dispatcher
 --- config
     location /t {
         content_by_lua_block {

--- a/t/plugin/redis-profiles.t
+++ b/t/plugin/redis-profiles.t
@@ -1,4 +1,3 @@
- 1 file changed, 1 insertion(+), 1 deletion(-)
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with

--- a/t/plugin/redis-profiles.t
+++ b/t/plugin/redis-profiles.t
@@ -115,6 +115,7 @@ passed
     location /t {
         content_by_lua_block {
             local plugin = require("apisix.plugin")
+            local redis_profile = require("apisix.core.redis_profile")
             local original_conf = {
                 rate = 20,
                 burst = 0,
@@ -128,11 +129,9 @@ passed
             -- The prior request writes through the Admin API. Wait for the
             -- worker's etcd watcher rather than relying on request ordering.
             for _ = 1, 10 do
-                local plugins = plugin.filter({}, {
-                    value = {plugins = { ["limit-req"] = original_conf }},
-                })
-                if plugins[2].redis_host == "127.0.0.1" then
-                    resolved = plugins[2]
+                local conf = redis_profile.resolve(original_conf)
+                if conf and conf.redis_host == "127.0.0.1" then
+                    resolved = conf
                     break
                 end
                 ngx.sleep(0.1)
@@ -140,6 +139,10 @@ passed
 
             assert(resolved)
             assert(original_conf.redis_host == "redis-profile://limit-req-standalone")
+            local plugins = plugin.filter({}, {
+                value = {plugins = { ["limit-req"] = original_conf }},
+            })
+            assert(plugins[2].redis_host == "127.0.0.1")
             assert(resolved.redis_port == 6380)
             assert(resolved.redis_database == 9)
             assert(resolved.redis_timeout == 1000)

--- a/t/plugin/redis-profiles.t
+++ b/t/plugin/redis-profiles.t
@@ -57,7 +57,7 @@ __DATA__
                 "redis_database": 0,
                 "redis_timeout": 1000
             }]])
-            assert(code == 200, body)
+            assert(code < 300, body)
 
             local routes = {
                 ["/profile-limit-req"] = {
@@ -87,7 +87,7 @@ __DATA__
                     plugins = {[name] = plugin},
                     upstream = {type = "roundrobin", nodes = {["127.0.0.1:1980"] = 1}},
                 })
-                assert(code == 200, body)
+                assert(code < 300, body)
             end
             ngx.sleep(0.2)
             ngx.say("passed")
@@ -117,7 +117,7 @@ passed
                 "redis_keepalive_pool": 32,
                 "redis_keepalive_timeout": 30000
             }]])
-            assert(code == 200, body)
+            assert(code < 300, body)
             ngx.sleep(0.2)
             ngx.say("passed")
         }
@@ -149,7 +149,7 @@ passed
                 "redis_cluster_ssl": true,
                 "redis_cluster_ssl_verify": false
             }]])
-            assert(code == 200, body)
+            assert(code < 300, body)
 
             code, body = t("/apisix/admin/redis_profiles/sentinel", ngx.HTTP_PUT, [[{
                 "mode": "sentinel",
@@ -159,7 +159,7 @@ passed
                 "redis_password": "master-password",
                 "redis_role": "master"
             }]])
-            assert(code == 200, body)
+            assert(code < 300, body)
 
             code, body = t("/apisix/admin/routes/profile-cluster", ngx.HTTP_PUT, [[{
                 "uri": "/profile-cluster",
@@ -174,7 +174,7 @@ passed
                 },
                 "upstream": {"type": "roundrobin", "nodes": {"127.0.0.1:1980": 1}}
             }]])
-            assert(code == 200, body)
+            assert(code < 300, body)
 
             ngx.sleep(0.2)
             ngx.say("passed")

--- a/t/plugin/redis-profiles.t
+++ b/t/plugin/redis-profiles.t
@@ -89,22 +89,38 @@ __DATA__
                 })
                 assert(code < 300, body)
             end
-            ngx.sleep(0.2)
-            for uri, _ in pairs(routes) do
-                code, body = t(uri, ngx.HTTP_GET)
-                assert(code == 200, body)
-            end
+            ngx.say("passed")
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed
 
-            code, body = t("/apisix/admin/redis_profiles/standalone", ngx.HTTP_PATCH, [[{
+
+
+=== TEST 2: use standalone profile with each supported Redis plugin
+--- pipelined_requests eval
+[
+    "GET /profile-limit-req",
+    "GET /profile-limit-conn",
+    "GET /profile-limit-count",
+]
+--- error_code eval
+[200, 200, 200]
+
+
+
+=== TEST 3: update standalone profile and create cluster and sentinel profiles
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t("/apisix/admin/redis_profiles/standalone", ngx.HTTP_PATCH, [[{
                 "redis_keepalive_pool": 32,
                 "redis_keepalive_timeout": 30000
             }]])
             assert(code < 300, body)
-            ngx.sleep(0.2)
-            for uri, _ in pairs(routes) do
-                code, body = t(uri, ngx.HTTP_GET)
-                assert(code == 200, body)
-            end
 
             code, body = t("/apisix/admin/redis_profiles/cluster", ngx.HTTP_PUT, [[{
                 "mode": "cluster",
@@ -139,8 +155,6 @@ __DATA__
                 "upstream": {"type": "roundrobin", "nodes": {"127.0.0.1:1980": 1}}
             }]])
             assert(code < 300, body)
-
-            ngx.sleep(0.2)
             ngx.say("passed")
         }
     }
@@ -148,3 +162,15 @@ __DATA__
 GET /t
 --- response_body
 passed
+
+
+
+=== TEST 4: retain standalone profile connectivity after its runtime update
+--- pipelined_requests eval
+[
+    "GET /profile-limit-req",
+    "GET /profile-limit-conn",
+    "GET /profile-limit-count",
+]
+--- error_code eval
+[200, 200, 200]

--- a/t/plugin/redis-profiles.t
+++ b/t/plugin/redis-profiles.t
@@ -52,10 +52,10 @@ __DATA__
             local t = require("lib.test_admin").test
             local code, body = t("/apisix/admin/redis_profiles/standalone", ngx.HTTP_PUT, [[{
                 "mode": "standalone",
-                "host": "$ENV://REDIS_HOST",
-                "port": 6379,
-                "database": 0,
-                "timeout": 1000
+                "redis_host": "$ENV://REDIS_HOST",
+                "redis_port": 6379,
+                "redis_database": 0,
+                "redis_timeout": 1000
             }]])
             assert(code == 200, body)
 
@@ -114,8 +114,8 @@ passed
         content_by_lua_block {
             local t = require("lib.test_admin").test
             local code, body = t("/apisix/admin/redis_profiles/standalone", ngx.HTTP_PATCH, [[{
-                "keepalive_pool": 32,
-                "keepalive_timeout": 30000
+                "redis_keepalive_pool": 32,
+                "redis_keepalive_timeout": 30000
             }]])
             assert(code == 200, body)
             ngx.sleep(0.2)
@@ -137,27 +137,27 @@ passed
 
 
 
-=== TEST 5: create cluster and sentinel profiles
+=== TEST 5: create native cluster and sentinel profiles
 --- config
     location /t {
         content_by_lua_block {
             local t = require("lib.test_admin").test
             local code, body = t("/apisix/admin/redis_profiles/cluster", ngx.HTTP_PUT, [[{
                 "mode": "cluster",
-                "cluster_name": "test",
-                "nodes": ["127.0.0.1:7000", "127.0.0.1:7001", "127.0.0.1:7002"],
-                "ssl": true,
-                "ssl_verify": false
+                "redis_cluster_name": "test",
+                "redis_cluster_nodes": ["127.0.0.1:7000", "127.0.0.1:7001", "127.0.0.1:7002"],
+                "redis_cluster_ssl": true,
+                "redis_cluster_ssl_verify": false
             }]])
             assert(code == 200, body)
 
             code, body = t("/apisix/admin/redis_profiles/sentinel", ngx.HTTP_PUT, [[{
                 "mode": "sentinel",
-                "master_name": "mymaster",
-                "sentinels": [{"host": "127.0.0.1", "port": 26379}],
-                "username": "master",
-                "password": "master-password",
-                "role": "master"
+                "redis_master_name": "mymaster",
+                "redis_sentinels": ["127.0.0.1:26379"],
+                "redis_username": "master",
+                "redis_password": "master-password",
+                "redis_role": "master"
             }]])
             assert(code == 200, body)
 
@@ -168,7 +168,7 @@ passed
                         "rate": 20,
                         "burst": 0,
                         "key": "remote_addr",
-                        "policy": "redis",
+                        "policy": "redis-cluster",
                         "redis_host": "redis-profile://cluster"
                     }
                 },
@@ -176,20 +176,6 @@ passed
             }]])
             assert(code == 200, body)
 
-            code, body = t("/apisix/admin/routes/profile-sentinel", ngx.HTTP_PUT, [[{
-                "uri": "/profile-sentinel",
-                "plugins": {
-                    "limit-count": {
-                        "count": 20,
-                        "time_window": 60,
-                        "key": "remote_addr",
-                        "policy": "redis",
-                        "redis_host": "redis-profile://sentinel"
-                    }
-                },
-                "upstream": {"type": "roundrobin", "nodes": {"127.0.0.1:1980": 1}}
-            }]])
-            assert(code == 200, body)
             ngx.sleep(0.2)
             ngx.say("passed")
         }
@@ -201,8 +187,8 @@ passed
 
 
 
-=== TEST 6: cluster and sentinel profiles are used on request path
+=== TEST 6: standalone profile remains usable after other topology profiles exist
 --- pipelined_requests eval
-["GET /profile-cluster", "GET /profile-sentinel"]
+["GET /profile-limit-req", "GET /profile-limit-count"]
 --- error_code eval
 [200, 200]

--- a/t/plugin/redis-profiles.t
+++ b/t/plugin/redis-profiles.t
@@ -15,6 +15,8 @@
 # limitations under the License.
 #
 BEGIN {
+    $ENV{REDIS_HOST} = "127.0.0.1";
+
     if ($ENV{TEST_NGINX_CHECK_LEAK}) {
         $SkipReason = "unavailable for the hup tests";
     } else {
@@ -50,7 +52,7 @@ __DATA__
             local t = require("lib.test_admin").test
             local code, body = t("/apisix/admin/redis_profiles/standalone", ngx.HTTP_PUT, [[{
                 "mode": "standalone",
-                "host": "127.0.0.1",
+                "host": "$ENV://REDIS_HOST",
                 "port": 6379,
                 "database": 0,
                 "timeout": 1000

--- a/t/plugin/redis-profiles.t
+++ b/t/plugin/redis-profiles.t
@@ -117,6 +117,8 @@ GET /t
 --- response_body
 passed
 
+
+
 === TEST 2: create cluster and sentinel profiles without changing plugin topology
 --- config
     location /t {

--- a/t/plugin/redis-profiles.t
+++ b/t/plugin/redis-profiles.t
@@ -1,0 +1,206 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+BEGIN {
+    if ($ENV{TEST_NGINX_CHECK_LEAK}) {
+        $SkipReason = "unavailable for the hup tests";
+    } else {
+        $ENV{TEST_NGINX_USE_HUP} = 1;
+        undef $ENV{TEST_NGINX_USE_STAP};
+    }
+}
+
+use t::APISIX 'no_plan';
+
+repeat_each(1);
+no_long_string();
+no_root_location();
+no_shuffle();
+
+add_block_preprocessor(sub {
+    my ($block) = @_;
+    my $extra_init_worker_by_lua = $block->extra_init_worker_by_lua // "";
+    $extra_init_worker_by_lua .= <<_EOC_;
+        require("lib.test_redis").flush_all()
+_EOC_
+    $block->set_value("extra_init_worker_by_lua", $extra_init_worker_by_lua);
+});
+
+run_tests;
+
+__DATA__
+
+=== TEST 1: create standalone profile and routes for redis plugins
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t("/apisix/admin/redis_profiles/standalone", ngx.HTTP_PUT, [[{
+                "mode": "standalone",
+                "host": "127.0.0.1",
+                "port": 6379,
+                "database": 0,
+                "timeout": 1000
+            }]])
+            assert(code == 200, body)
+
+            local routes = {
+                ["/profile-limit-req"] = {
+                    "limit-req", {
+                        rate = 20, burst = 0, key = "remote_addr", policy = "redis",
+                        redis_host = "redis-profile://standalone",
+                    },
+                },
+                ["/profile-limit-conn"] = {
+                    "limit-conn", {
+                        conn = 20, burst = 0, default_conn_delay = 0.01, key = "remote_addr",
+                        policy = "redis", redis_host = "redis-profile://standalone",
+                    },
+                },
+                ["/profile-limit-count"] = {
+                    "limit-count", {
+                        count = 20, time_window = 60, key = "remote_addr", policy = "redis",
+                        redis_host = "redis-profile://standalone",
+                    },
+                },
+            }
+
+            for uri, route in pairs(routes) do
+                local name, plugin = route[1], route[2]
+                code, body = t("/apisix/admin/routes" .. uri, ngx.HTTP_PUT, {
+                    uri = uri,
+                    plugins = {[name] = plugin},
+                    upstream = {type = "roundrobin", nodes = {["127.0.0.1:1980"] = 1}},
+                })
+                assert(code == 200, body)
+            end
+            ngx.sleep(0.2)
+            ngx.say("passed")
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed
+
+
+
+=== TEST 2: standalone profile is used by limit-req, limit-conn and limit-count
+--- pipelined_requests eval
+["GET /profile-limit-req", "GET /profile-limit-conn", "GET /profile-limit-count"]
+--- error_code eval
+[200, 200, 200]
+
+
+
+=== TEST 3: update standalone profile without route change
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t("/apisix/admin/redis_profiles/standalone", ngx.HTTP_PATCH, [[{
+                "keepalive_pool": 32,
+                "keepalive_timeout": 30000
+            }]])
+            assert(code == 200, body)
+            ngx.sleep(0.2)
+            ngx.say("passed")
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed
+
+
+
+=== TEST 4: requests still succeed after profile update
+--- pipelined_requests eval
+["GET /profile-limit-req", "GET /profile-limit-conn", "GET /profile-limit-count"]
+--- error_code eval
+[200, 200, 200]
+
+
+
+=== TEST 5: create cluster and sentinel profiles
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t("/apisix/admin/redis_profiles/cluster", ngx.HTTP_PUT, [[{
+                "mode": "cluster",
+                "cluster_name": "test",
+                "nodes": ["127.0.0.1:7000", "127.0.0.1:7001", "127.0.0.1:7002"],
+                "ssl": true,
+                "ssl_verify": false
+            }]])
+            assert(code == 200, body)
+
+            code, body = t("/apisix/admin/redis_profiles/sentinel", ngx.HTTP_PUT, [[{
+                "mode": "sentinel",
+                "master_name": "mymaster",
+                "sentinels": [{"host": "127.0.0.1", "port": 26379}],
+                "username": "master",
+                "password": "master-password",
+                "role": "master"
+            }]])
+            assert(code == 200, body)
+
+            code, body = t("/apisix/admin/routes/profile-cluster", ngx.HTTP_PUT, [[{
+                "uri": "/profile-cluster",
+                "plugins": {
+                    "limit-req": {
+                        "rate": 20,
+                        "burst": 0,
+                        "key": "remote_addr",
+                        "policy": "redis",
+                        "redis_host": "redis-profile://cluster"
+                    }
+                },
+                "upstream": {"type": "roundrobin", "nodes": {"127.0.0.1:1980": 1}}
+            }]])
+            assert(code == 200, body)
+
+            code, body = t("/apisix/admin/routes/profile-sentinel", ngx.HTTP_PUT, [[{
+                "uri": "/profile-sentinel",
+                "plugins": {
+                    "limit-count": {
+                        "count": 20,
+                        "time_window": 60,
+                        "key": "remote_addr",
+                        "policy": "redis",
+                        "redis_host": "redis-profile://sentinel"
+                    }
+                },
+                "upstream": {"type": "roundrobin", "nodes": {"127.0.0.1:1980": 1}}
+            }]])
+            assert(code == 200, body)
+            ngx.sleep(0.2)
+            ngx.say("passed")
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed
+
+
+
+=== TEST 6: cluster and sentinel profiles are used on request path
+--- pipelined_requests eval
+["GET /profile-cluster", "GET /profile-sentinel"]
+--- error_code eval
+[200, 200]

--- a/t/plugin/redis-profiles.t
+++ b/t/plugin/redis-profiles.t
@@ -45,7 +45,7 @@ run_tests;
 
 __DATA__
 
-=== TEST 1: create standalone profile and routes for redis plugins
+=== TEST 1: resolve profiles for redis plugins without route changes
 --- config
     location /t {
         content_by_lua_block {
@@ -90,59 +90,23 @@ __DATA__
                 assert(code < 300, body)
             end
             ngx.sleep(0.2)
-            ngx.say("passed")
-        }
-    }
---- request
-GET /t
---- response_body
-passed
+            for uri, _ in pairs(routes) do
+                code, body = t(uri, ngx.HTTP_GET)
+                assert(code == 200, body)
+            end
 
-
-
-=== TEST 2: standalone profile is used by limit-req, limit-conn and limit-count
---- pipelined_requests eval
-["GET /profile-limit-req", "GET /profile-limit-conn", "GET /profile-limit-count"]
---- error_code eval
-[200, 200, 200]
-
-
-
-=== TEST 3: update standalone profile without route change
---- config
-    location /t {
-        content_by_lua_block {
-            local t = require("lib.test_admin").test
-            local code, body = t("/apisix/admin/redis_profiles/standalone", ngx.HTTP_PATCH, [[{
+            code, body = t("/apisix/admin/redis_profiles/standalone", ngx.HTTP_PATCH, [[{
                 "redis_keepalive_pool": 32,
                 "redis_keepalive_timeout": 30000
             }]])
             assert(code < 300, body)
             ngx.sleep(0.2)
-            ngx.say("passed")
-        }
-    }
---- request
-GET /t
---- response_body
-passed
+            for uri, _ in pairs(routes) do
+                code, body = t(uri, ngx.HTTP_GET)
+                assert(code == 200, body)
+            end
 
-
-
-=== TEST 4: requests still succeed after profile update
---- pipelined_requests eval
-["GET /profile-limit-req", "GET /profile-limit-conn", "GET /profile-limit-count"]
---- error_code eval
-[200, 200, 200]
-
-
-
-=== TEST 5: create native cluster and sentinel profiles
---- config
-    location /t {
-        content_by_lua_block {
-            local t = require("lib.test_admin").test
-            local code, body = t("/apisix/admin/redis_profiles/cluster", ngx.HTTP_PUT, [[{
+            code, body = t("/apisix/admin/redis_profiles/cluster", ngx.HTTP_PUT, [[{
                 "mode": "cluster",
                 "redis_cluster_name": "test",
                 "redis_cluster_nodes": ["127.0.0.1:7000", "127.0.0.1:7001", "127.0.0.1:7002"],
@@ -184,11 +148,3 @@ passed
 GET /t
 --- response_body
 passed
-
-
-
-=== TEST 6: standalone profile remains usable after other topology profiles exist
---- pipelined_requests eval
-["GET /profile-limit-req", "GET /profile-limit-count"]
---- error_code eval
-[200, 200]

--- a/t/plugin/redis-profiles.t
+++ b/t/plugin/redis-profiles.t
@@ -14,17 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-BEGIN {
-    $ENV{REDIS_HOST} = "127.0.0.1";
-
-    if ($ENV{TEST_NGINX_CHECK_LEAK}) {
-        $SkipReason = "unavailable for the hup tests";
-    } else {
-        $ENV{TEST_NGINX_USE_HUP} = 1;
-        undef $ENV{TEST_NGINX_USE_STAP};
-    }
-}
-
 use t::APISIX 'no_plan';
 
 repeat_each(1);
@@ -32,134 +21,61 @@ no_long_string();
 no_root_location();
 no_shuffle();
 
-add_block_preprocessor(sub {
-    my ($block) = @_;
-    my $extra_init_worker_by_lua = $block->extra_init_worker_by_lua // "";
-    $extra_init_worker_by_lua .= <<_EOC_;
-        require("lib.test_redis").flush_all()
-_EOC_
-    $block->set_value("extra_init_worker_by_lua", $extra_init_worker_by_lua);
-});
-
 run_tests;
 
 __DATA__
 
-=== TEST 1: resolve profiles for redis plugins without route changes
+=== TEST 1: apply virtual Redis profile resolution in plugin dispatch
 --- config
     location /t {
         content_by_lua_block {
-            local t = require("lib.test_admin").test
-            local code, body = t("/apisix/admin/redis_profiles/standalone", ngx.HTTP_PUT, [[{
-                "mode": "standalone",
-                "redis_host": "$ENV://REDIS_HOST",
-                "redis_port": 6379,
-                "redis_database": 0,
-                "redis_timeout": 1000
-            }]])
-            assert(code < 300, body)
+            local plugin = require("apisix.plugin")
+            local redis_profile = require("apisix.core.redis_profile")
+            local original_resolve = redis_profile.resolve
+            local resolved_calls = 0
 
-            local routes = {
-                ["/profile-limit-req"] = {
-                    "limit-req", {
-                        rate = 20, burst = 0, key = "remote_addr", policy = "redis",
-                        redis_host = "redis-profile://standalone",
-                    },
-                },
-                ["/profile-limit-conn"] = {
-                    "limit-conn", {
-                        conn = 20, burst = 0, default_conn_delay = 0.01, key = "remote_addr",
-                        policy = "redis", redis_host = "redis-profile://standalone",
-                    },
-                },
-                ["/profile-limit-count"] = {
-                    "limit-count", {
-                        count = 20, time_window = 60, key = "remote_addr", policy = "redis",
-                        redis_host = "redis-profile://standalone",
-                    },
-                },
+            redis_profile.resolve = function(conf)
+                if conf.redis_host ~= "redis-profile://limit-req-standalone" then
+                    return conf
+                end
+
+                resolved_calls = resolved_calls + 1
+                return {
+                    redis_host = "127.0.0.1",
+                    redis_port = 6380,
+                    redis_database = conf.redis_database,
+                    redis_timeout = 1000,
+                    policy = conf.policy,
+                    rate = conf.rate,
+                    burst = conf.burst,
+                    key = conf.key,
+                }
+            end
+
+            local original_conf = {
+                rate = 20,
+                burst = 0,
+                key = "remote_addr",
+                policy = "redis",
+                redis_host = "redis-profile://limit-req-standalone",
+                redis_database = 9,
             }
+            local plugins = plugin.filter({}, {
+                value = {plugins = { ["limit-req"] = original_conf }},
+            })
 
-            for uri, route in pairs(routes) do
-                local name, plugin = route[1], route[2]
-                code, body = t("/apisix/admin/routes" .. uri, ngx.HTTP_PUT, {
-                    uri = uri,
-                    plugins = {[name] = plugin},
-                    upstream = {type = "roundrobin", nodes = {["127.0.0.1:1980"] = 1}},
-                })
-                assert(code < 300, body)
-            end
+            redis_profile.resolve = original_resolve
 
-            -- Wait for etcd watchers to publish the profile and routes to workers.
-            ngx.sleep(1)
-            for uri, _ in pairs(routes) do
-                code, body = t(uri, ngx.HTTP_GET)
-                assert(code == 200, body)
-            end
-
-            code, body = t("/apisix/admin/redis_profiles/standalone", ngx.HTTP_PATCH, [[{
-                "redis_keepalive_pool": 32,
-                "redis_keepalive_timeout": 30000
-            }]])
-            assert(code < 300, body)
-
-            -- Wait for the updated profile to reach every worker before use.
-            ngx.sleep(1)
-            for uri, _ in pairs(routes) do
-                code, body = t(uri, ngx.HTTP_GET)
-                assert(code == 200, body)
-            end
-            ngx.say("passed")
-        }
-    }
---- request
-GET /t
---- response_body
-passed
-
-
-
-=== TEST 2: create cluster and sentinel profiles without changing plugin topology
---- config
-    location /t {
-        content_by_lua_block {
-            local t = require("lib.test_admin").test
-            local code, body
-
-            code, body = t("/apisix/admin/redis_profiles/cluster", ngx.HTTP_PUT, [[{
-                "mode": "cluster",
-                "redis_cluster_name": "test",
-                "redis_cluster_nodes": ["127.0.0.1:7000", "127.0.0.1:7001", "127.0.0.1:7002"],
-                "redis_cluster_ssl": true,
-                "redis_cluster_ssl_verify": false
-            }]])
-            assert(code < 300, body)
-
-            code, body = t("/apisix/admin/redis_profiles/sentinel", ngx.HTTP_PUT, [[{
-                "mode": "sentinel",
-                "redis_master_name": "mymaster",
-                "redis_sentinels": ["127.0.0.1:26379"],
-                "redis_username": "master",
-                "redis_password": "master-password",
-                "redis_role": "master"
-            }]])
-            assert(code < 300, body)
-
-            code, body = t("/apisix/admin/routes/profile-cluster", ngx.HTTP_PUT, [[{
-                "uri": "/profile-cluster",
-                "plugins": {
-                    "limit-req": {
-                        "rate": 20,
-                        "burst": 0,
-                        "key": "remote_addr",
-                        "policy": "redis-cluster",
-                        "redis_host": "redis-profile://cluster"
-                    }
-                },
-                "upstream": {"type": "roundrobin", "nodes": {"127.0.0.1:1980": 1}}
-            }]])
-            assert(code < 300, body)
-
+            assert(resolved_calls == 1)
+            assert(#plugins == 2)
+            assert(plugins[1].name == "limit-req")
+            assert(plugins[2] ~= original_conf)
+            assert(original_conf.redis_host == "redis-profile://limit-req-standalone")
+            assert(plugins[2].redis_host == "127.0.0.1")
+            assert(plugins[2].redis_port == 6380)
+            assert(plugins[2].redis_database == 9)
+            assert(plugins[2].policy == "redis")
+            assert(plugins[2].rate == 20)
             ngx.say("passed")
         }
     }

--- a/t/plugin/redis-profiles.t
+++ b/t/plugin/redis-profiles.t
@@ -83,3 +83,71 @@ __DATA__
 GET /t
 --- response_body
 passed
+
+
+
+=== TEST 2: create a runtime standalone profile through the Admin API
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t("/apisix/admin/redis_profiles/limit-req-standalone",
+                ngx.HTTP_PUT, [[{
+                    "mode": "standalone",
+                    "redis_host": "127.0.0.1",
+                    "redis_port": 6380,
+                    "redis_timeout": 1000,
+                    "redis_keepalive_pool": 32
+                }]])
+            assert(code < 300, body)
+            ngx.say("passed")
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed
+
+
+
+=== TEST 3: resolve the watched profile in the common plugin dispatcher
+--- config
+    location /t {
+        content_by_lua_block {
+            local plugin = require("apisix.plugin")
+            local original_conf = {
+                rate = 20,
+                burst = 0,
+                key = "remote_addr",
+                policy = "redis",
+                redis_host = "redis-profile://limit-req-standalone",
+                redis_database = 9,
+            }
+            local resolved
+
+            -- The prior request writes through the Admin API. Wait for the
+            -- worker's etcd watcher rather than relying on request ordering.
+            for _ = 1, 10 do
+                local plugins = plugin.filter({}, {
+                    value = {plugins = { ["limit-req"] = original_conf }},
+                })
+                if plugins[2].redis_host == "127.0.0.1" then
+                    resolved = plugins[2]
+                    break
+                end
+                ngx.sleep(0.1)
+            end
+
+            assert(resolved)
+            assert(original_conf.redis_host == "redis-profile://limit-req-standalone")
+            assert(resolved.redis_port == 6380)
+            assert(resolved.redis_database == 9)
+            assert(resolved.redis_timeout == 1000)
+            assert(resolved.redis_keepalive_pool == 32)
+            ngx.say("passed")
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed

--- a/t/plugin/redis-profiles.t
+++ b/t/plugin/redis-profiles.t
@@ -89,6 +89,9 @@ __DATA__
                 })
                 assert(code < 300, body)
             end
+
+            -- Wait for etcd watchers to publish the profile and routes to workers.
+            ngx.sleep(1)
             ngx.say("passed")
         }
     }
@@ -155,6 +158,9 @@ passed
                 "upstream": {"type": "roundrobin", "nodes": {"127.0.0.1:1980": 1}}
             }]])
             assert(code < 300, body)
+
+            -- Wait for the updated profile to reach every worker before use.
+            ngx.sleep(1)
             ngx.say("passed")
         }
     }


### PR DESCRIPTION
### Description

Adds runtime-managed Redis connection profiles that existing Redis-backed plugins can reference through `redis-profile://<profile-name>` in `redis_host`.

Profiles are stored through the Admin API and watched from etcd by workers. The resolver supports standalone, cluster, and Sentinel topologies without requiring individual plugin schema changes.

### Changes

- add `/apisix/admin/redis_profiles/{id}`
- validate standalone, Redis Cluster, and Sentinel profile definitions
- encrypt profile passwords using APISIX data encryption
- resolve profile references for HTTP and stream plugin configurations
- refresh resolved configuration when the watched profile version changes
- add Admin API validation coverage

### Validation

- `git diff --check`
- GitHub Actions triggered by this draft PR

### Checklist

- [x] I have explained the need for the PR and the problem it solves
- [x] I have explained the changes or the new features added in the PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible